### PR TITLE
sync: make safe progress before review updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,9 @@ portion as one operation. A one-PR review uses GitHub's ordinary pull-request me
 `merge` never pushes trunk, rewrites local history, or removes review tracking. Run
 `jj-stack sync <head-change-id>` after GitHub merges lower changes. It rebases the remaining
 selected changes onto `trunk()`, updates only PRs that already exist for them, and cleans up a
-merged PR when no PR above still needs its review branch. Unreviewed trailing work stays local,
-and other local stacks are left alone. Preview it with
+merged PR when no local path still needs it. Conflicts remain local for you to resolve before
+their PRs are updated. Ordinary `jj` rewrite propagation may also rebase local descendants, but
+`sync` updates reviews only for the selected stack. Preview it with
 `jj-stack sync --dry-run <head-change-id>`; if a rebase is needed, the later PR-update plan is
 available only after you run `sync`.
 

--- a/docs/daily-workflow.md
+++ b/docs/daily-workflow.md
@@ -271,20 +271,40 @@ jj-stack sync <head-change-id>
 
 `sync` fetches trunk, verifies which lower PRs GitHub merged, rebases the remaining selected
 changes, and updates only PRs that already exist for them. It does not open a PR for trailing WIP
-or touch other local stacks. If it cannot safely remove an old local copy, it leaves the change
-alone and prints the commits and inspection step that explain the stop.
+or update reviews outside the selected stack. As with any `jj` rewrite, rebasing a selected change
+may also rebase its local descendants.
 
 GitHub may preserve a change as it merges or create a different commit, as a squash merge does.
 `sync` handles either result without pretending the new GitHub commit is the old local change.
 If a stack merge also rewrote the PRs that remain open, `sync` adopts those exact reviewed
 commits and rebases only your trailing local work above them.
 
-If reviewed work is already on fetched trunk but its local copy still follows unmerged changes,
-`sync` cannot choose their intended order. It changes nothing and prints the earlier change IDs,
-the submitted, local, and fetched-trunk commits, and an exact `jj log` command. Inspect that
-history and choose the order with ordinary `jj`; ask an agent to inspect the repository if useful.
-Then run `jj-stack view` for the remaining local reviews. Sync a remaining mutable reviewed head,
-or run `jj-stack cleanup` if no reviewed local copy remains.
+The local DAG stops `sync` before it rebases in these cases:
+
+- A remaining change has multiple visible revisions, so there is no single revision to rebase.
+- A merged change has local edits made after submit. Removing it would discard those edits.
+- A local change that has not merged is a parent of reviewed work that has merged. Moving the
+  local change could put it before or after the merged work, and `sync` will not choose for you.
+- An unreviewed change sits between reviewed changes. `sync` updates existing PRs but never
+  creates the missing review.
+
+When the order between an unmerged parent and merged review is ambiguous, the diagnostic prints
+the relevant change IDs and commits plus an exact `jj log` command. Inspect both histories and
+choose the order with ordinary `jj`; ask an agent to inspect the repository if useful. Then run
+`jj-stack view`. Sync a remaining mutable reviewed head, or run `jj-stack cleanup` if no reviewed
+local copy remains.
+
+Before rebasing, `sync` also checks the configured remote, fetched trunk, saved PR links, and
+GitHub stack membership. A missing, moved, closed, or ambiguous review stops the run before local
+history changes. The diagnostic names the state to inspect or repair.
+
+Conflicts do not prevent the local rebase. If a reviewed change remains conflicted afterward,
+`sync` leaves the rebase in place and stops before updating that PR. Resolve the conflict with
+`jj`, then run `jj-stack submit <head-change-id>`.
+
+If another local path still depends on an old merged change, `sync` leaves that change and its
+tracking in place. It prints the head of each other stack that still needs `sync`. Work completed
+before any later stop remains in place, and rerunning `sync` continues from the current state.
 
 `sync` does not otherwise rewrite history. If your stack simply drifted because `trunk()`
 advanced without anything in your stack merging, rebase only the intended bottom-to-head path

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -9,7 +9,7 @@ matches; codes 7-9 are reserved because their `gh stack` meanings have no jj-sta
 | 0 | Success. |
 | 1 | Any other failure, including a command stopped by a blocked action. |
 | 2 | The selection does not form a supported review stack. |
-| 3 | Unresolved conflicts in the selected changes block the operation. |
+| 3 | Unresolved conflicts prevented a review update. |
 | 4 | GitHub authentication, network, or API failure. |
 | 5 | Invalid command-line arguments. |
 | 6 | A selector matched more than one target, so the command failed closed. |
@@ -30,6 +30,8 @@ Notes:
   together with the payload. See [json-output.md](json-output.md).
 - Commands that mutate review state (`submit`, `merge`, `sync`, `unstack`, `cleanup`) exit 1 when
   they ran but had to stop before completing every action; command output names what blocked them.
+- `sync` may finish its local rebase before exiting 3. Its message says whether to resolve the
+  conflicts and continue with `submit`.
 - Exit 2 covers selections `jj-stack` cannot review as a linear stack: a merge commit, a divergent
   change, a hidden or immutable commit, an empty or undescribed working copy, a path that never
   reaches `trunk()`, and a repository with no trunk bookmark configured. The message names the

--- a/docs/internals/design.md
+++ b/docs/internals/design.md
@@ -85,11 +85,12 @@ the selected path until `sync` reconciles it.
 `jj-stack` supports only linear stacks, so the walk follows each commit's sole parent. A merge
 commit inside the selected chain is rejected, as is a divergent review change. Unresolved
 conflicts are a separate matter: they do not break the shape, so `view` and `list` report a
-conflicted change, while `submit`, `merge`, and `sync` refuse to act on one.
+conflicted change. `submit` and `merge` refuse to act on one. `sync` may rebase it locally but
+does not update its review until the conflict is resolved.
 
-Commands validate only the selected chain. Other visible children elsewhere in the DAG are not
-an error. If an ancestor on the selected chain has another reviewable child, that child and its
-descendants are out of scope unless the command explicitly selects them.
+Commands plan review mutations from the selected chain. Other visible children elsewhere in the
+DAG are not an error. A `sync` rebase may also move descendants when `jj` propagates a rewrite,
+but it never updates reviews outside the selected chain.
 
 A rebase merge preserves `jj`'s change ID, so once the result is fetched, the commit on
 trunk and the superseded local commit are two visible copies of one change ID: the local copy is
@@ -363,7 +364,8 @@ Three modes deliberately reach beyond one selected stack:
 - `unstack --cleanup --pull-request <pr>`, which may select one tracked PR whose local change is
   gone, and `unstack --cleanup --pull-request orphans`, which selects all such PRs
 
-No default invocation mutates beyond the selected stack. Ambiguous selectors always fail closed.
+No default invocation mutates reviews beyond the selected stack. A `sync` rebase may propagate to
+local descendants under ordinary `jj` rewrite rules. Ambiguous selectors always fail closed.
 
 ### Identity and mutation preconditions
 
@@ -476,26 +478,27 @@ Two observations prove that reviewed work reached trunk. GitHub reporting a pull
 merged is not one of them, because it says nothing about the trunk this repository fetched:
 
 - **Exact submitted commit on trunk**: the baseline is an ancestor of fetched trunk and the live
-  PR is a snapshot match. A PR belonging to a GitHub stack must also report merged before selected
-  `sync` may act on it.
+  PR is a snapshot match. A PR belonging to a GitHub stack must also report merged before `sync`
+  may act on it.
 - **Selected PR's rewritten merge result on trunk**: the saved PR is an identity match, reports
   merged, still reports the submitted head, and reports a merge-result commit that is an ancestor
   of fetched trunk. This covers squash and rebase results.
 
-`sync` may use either proof. `sync --all` may use only exact submitted-commit evidence
-because a rewritten merge result is selected-stack evidence and cannot support repository-wide
-local change.
+`sync` may use either proof. `sync --all` may use only exact submitted-commit evidence because a
+rewritten merge result proves only the stack named by the command and cannot support
+repository-wide local change.
 
 A PR merely reporting merged, or a merge result no longer reachable from fetched trunk,
 permits no change. Local revisions, identity, and baseline remain untouched until a later sync can
 prove the result on fetched trunk.
 
-When unmerged local changes precede the local copy of reviewed work proven on fetched trunk,
-`sync` stops without mutation. It names the earlier changes and the exact submitted,
-local, and fetched-trunk commits, then gives a `jj log` command for inspecting the two histories.
-The user chooses the intended order with ordinary `jj`, with agent help if useful. Afterward they
-inspect the remaining local reviews, sync a remaining mutable reviewed head, or run cleanup when
-no reviewed local copy remains.
+When an unmerged local change sits below a reviewed change whose submitted work is proven on
+fetched trunk, `sync` stops without mutation. Rebasing would silently decide whether that local
+change belongs before or after the merged work. The diagnostic names the changes and the exact
+submitted, local, and fetched-trunk commits, then gives a `jj log` command for inspecting both
+histories. The user chooses the intended order with ordinary `jj`, with agent help if useful.
+Afterward they inspect the remaining local reviews, sync a remaining mutable reviewed head, or run
+cleanup when no reviewed local copy remains.
 
 Here unpublished local work means a mutable revision whose commit is neither its submitted
 baseline nor an exact GitHub stack head that this run may adopt.
@@ -503,14 +506,22 @@ baseline nor an exact GitHub stack head that this run may adopt.
 `sync` reconciles the unmerged suffix only when:
 
 - rewriting it would not discard unpublished local work
-- the remainder is linear and conflict-free
+- no surviving change is divergent
 - no unreviewed change sits between reviewed survivors
-- no other ordinary linear review path, including one ending at the invoking workspace's
-  described, nonempty working copy, depends on retiring a revision whose work is on trunk
 
-It rebases surviving changes onto fetched trunk, updates existing reviews, and removes tracking
-for changes on trunk only after survivor updates succeed. It never rebases merely because trunk
-advanced; ordinary `jj rebase` owns that workflow.
+It rebases surviving changes onto fetched trunk even when they contain conflicts. If a reviewed
+survivor remains conflicted, the local rebase stays in place but its review is not updated. The
+user resolves the conflict with `jj` and runs `submit` for the remaining stack.
+
+Rewriting a selected revision may also rebase its local descendants under ordinary `jj` rules. If
+another local path still depends on a merged revision after that rewrite, `sync` leaves the
+revision and its tracking in place and names each other stack that still needs `sync`. It never
+updates reviews outside the selected chain.
+
+Tracking for changes on trunk is removed only after survivor updates succeed and no local path
+still needs it. A failure after local convergence leaves completed work in place; a rerun observes
+the current DAG, tracking, and GitHub state and continues from there. `sync` never rebases merely
+because trunk advanced; ordinary `jj rebase` owns that workflow.
 
 GitHub preserves `jj`'s `change-id` commit header through rebase merges of PRs, but not squash
 merges. A matching full change ID on fetched trunk identifies the successor rather than
@@ -645,8 +656,9 @@ explicit rules:
 ### Cross-stack rewrites
 
 When a rewrite moves changes between local stacks, identity still follows full `change_id`, each
-stack command still acts on one selected chain, and ambiguous linkage still fails closed. Other
-affected stacks wait for their own explicit commands.
+stack command still updates reviews for one selected chain, and ambiguous linkage still fails
+closed. Local `jj` rewrites may propagate to descendants on another path. Reviews on that path
+wait for their own explicit commands.
 
 - **Move changes between stacks**: dissolve any existing GitHub stack spanning more than one
   resulting path, then submit one resulting stack to update that chain. Moved changes retain their

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -137,8 +137,8 @@ changes above the current `trunk()`, and updates only PRs that already exist for
 `jj-stack sync --dry-run <head-change-id>` first to preview merged changes and any cleanup or
 rebase. If a rebase is needed, its later PR-update plan is available only after you run `sync`.
 When a stack merge rewrote the PRs that remain open, `sync` adopts those exact reviewed commits
-and rebases only trailing local work above them. It leaves other stacks and unreviewed trailing
-changes alone.
+and rebases trailing local work above them. Ordinary `jj` rewrite propagation may also rebase
+local descendants, but `sync` updates reviews only for the selected stack.
 
 ## Reviewed work is on trunk but an earlier local change remains
 
@@ -169,12 +169,22 @@ Use the bounded bottom-to-head revset so sibling paths are not rewritten. Then r
 
 ## `sync` rebased the stack but reported conflicts
 
-The local rebase happened, but `jj-stack` did not update conflicting changes on GitHub. Inspect
-the conflicts with `jj status`, resolve them using your normal `jj` workflow, and then run:
+`sync` can rebase a change that was already conflicted, and a clean change can become
+conflicted during the rebase. In either case, the local rebase remains in place but `jj-stack`
+does not update the conflicting review on GitHub. Inspect the conflicts with `jj status`, resolve
+them using your normal `jj` workflow, and then run:
 
 ```bash
 jj-stack submit <head-change-id>
 ```
+
+## `sync` says another local stack still needs a merged change
+
+Two local paths still depend on the same reviewed change. `sync` rebased the path you selected,
+but it did not remove the shared change or its tracking because the other path still needs them.
+
+Run each `jj-stack sync <head-change-id>` command printed by the message. After every dependent
+path has moved to trunk, the last run can remove the old local change and its tracking.
 
 ## `list` or `view` says another stack changed since its last submit
 

--- a/src/jj_stack/commands/sync.py
+++ b/src/jj_stack/commands/sync.py
@@ -1,18 +1,40 @@
 """Update a stack after GitHub merges, or clean up merged reviews with `sync --all`.
 
-This is the one command that changes local history. For a selected stack it fetches trunk, checks
-which pull requests at the bottom GitHub merged, abandons those local changes, rebases the
-remaining ones onto the new trunk, and updates the pull requests that already exist for them. It
-opens no new pull requests and leaves other stacks alone.
+`sync` is the only jj-stack command that changes local history. It fetches trunk and proves
+which reviewed changes reached it. It then rebases the remaining changes, updates only their
+existing pull requests, and retires reviews that no local path still needs. It never creates a
+pull request.
 
-Some states stop the whole run instead: a remaining change that is conflicted or divergent,
-unpublished local edits on a change GitHub already merged, reviewed work on fetched trunk whose
-local copy still follows unmerged changes, or another local stack built on the same changes.
-Follow the inspection or repair named by the message.
+Some local states stop `sync` before it rebases:
+
+- A remaining change has multiple visible revisions. `sync` cannot choose one.
+
+- A merged change contains edits made after it was submitted. Removing it would discard work.
+
+- A local change that has not merged is a parent of reviewed work that has merged. Moving the
+  local change could put it before or after the merged work. `sync` will not choose for you.
+
+- An unreviewed change sits between reviewed changes. `sync` updates existing pull requests but
+  never creates the missing review.
+
+Before rebasing, `sync` also checks the configured remote, fetched trunk, saved pull request
+links, and GitHub stack membership. A missing, moved, closed, or ambiguous review stops the run
+before local history changes. The message names the state to inspect or repair.
+
+Conflicts do not prevent the local rebase. If a rebased review remains conflicted, `sync` leaves
+the conflict in local history and stops before updating that pull request. Resolve the conflict
+with `jj`, then run `jj-stack submit`.
+
+Rebasing a `jj` change also rebases its descendants. This may move local work above the selected
+stack, but `sync` updates pull requests only for the selected stack.
+
+A different local path may share a merged change with the stack being synced. If that path still
+uses the old local change, `sync` leaves the change and its tracking in place. It prints the other
+stack to sync next. A rerun observes work already completed and continues from there.
 
 `sync --all` never rebases or submits. It checks every locally tracked pull request and removes
-tracking for those whose submitted commit is already on trunk, printing a `jj-stack sync
-<head-change-id>` command for stacks that need the rebasing form instead.
+tracking for those whose submitted commit is already on trunk. For stacks that need a rebase, it
+prints a `jj-stack sync <head-change-id>` command instead.
 
 Use plain `jj rebase` when trunk merely advanced and nothing in the stack merged.
 """
@@ -31,7 +53,7 @@ from jj_stack.commands.submit.command import print_selected_line, run_submit_asy
 from jj_stack.commands.submit.models import SubmitOptions
 from jj_stack.commands.submit.render import print_submit_result
 from jj_stack.commands.sync_global import run_global_recovery
-from jj_stack.errors import CliError, UsageError
+from jj_stack.errors import CliError, ConflictedStackError, UsageError
 from jj_stack.github.client import GithubClient, build_github_client
 from jj_stack.github.resolution import GithubTarget, resolve_trunk_branch
 from jj_stack.jj.cli_args import JjCliArgs
@@ -382,14 +404,25 @@ async def _update_selected_reviews(
         else:
             console.output("Nothing to submit: everything in this stack has merged.")
         return 0
-    result = await run_submit_async(
-        context=context,
-        on_prepared=None,
-        options=_sync_submit_options(
-            dry_run=dry_run,
-            revset=plan.reviewed_survivors[-1].change_id,
-        ),
-    )
+    head_change_id = plan.reviewed_survivors[-1].change_id
+    try:
+        result = await run_submit_async(
+            context=context,
+            on_prepared=None,
+            options=_sync_submit_options(
+                dry_run=dry_run,
+                revset=head_change_id,
+            ),
+        )
+    except ConflictedStackError as error:
+        if not plan.on_trunk:
+            raise
+        raise ConflictedStackError(
+            error.message,
+            hint=t"The local rebase is complete. Resolve the conflicts with {ui.cmd('jj')}, "
+            t"then update the remaining reviews with "
+            t"{ui.cmd(f'jj-stack submit {head_change_id}')}",
+        ) from error
     print_submit_result(result)
     return 0
 

--- a/src/jj_stack/review/convergence.py
+++ b/src/jj_stack/review/convergence.py
@@ -105,9 +105,11 @@ def build_selected_convergence_plan(
             continue
         if survivors:
             raise CliError(
-                t"Reviewed {ui.change_id(revision.change_id)} is proven on fetched trunk, but "
-                t"its local copy still follows unmerged local changes: "
-                t"{ui.join(lambda item: ui.change_id(item.change_id), tuple(survivors))}.\n"
+                t"Cannot sync reviewed {ui.change_id(revision.change_id)} because these "
+                t"unmerged local changes are its parents: "
+                t"{ui.join(lambda item: ui.change_id(item.change_id), tuple(survivors))}. "
+                t"The submitted review is already on fetched trunk, so sync cannot decide "
+                t"whether those local changes belong before or after it.\n"
                 t"Submitted commit: "
                 t"{ui.semantic_text(candidate.submitted_baseline.commit_id, 'commit_id')}\n"
                 t"Local copy commit: {ui.semantic_text(revision.commit_id, 'commit_id')}\n"
@@ -175,7 +177,7 @@ def build_selected_convergence_plan(
         reviewed_survivors=tuple(reviewed),
         survivors=tuple(survivors),
     )
-    _validate_rebase_scope(context=context, plan=plan)
+    _require_no_divergent_survivors(plan)
     return plan
 
 
@@ -217,50 +219,15 @@ def _trunk_evidence_kind_for(
     return evidence_kind
 
 
-def _validate_rebase_scope(
-    *,
-    context: CommandContext,
-    plan: SelectedConvergencePlan,
-) -> None:
+def _require_no_divergent_survivors(plan: SelectedConvergencePlan) -> None:
     for revision in plan.survivors:
-        if revision.conflict or revision.divergent:
+        if revision.divergent:
             raise CliError(
-                t"The changes remaining after the merge are not linear at "
-                t"{ui.change_id(revision.change_id)}.",
-                hint=t"Resolve the conflict or divergence with {ui.cmd('jj')}, then rerun sync "
-                t"for this stack.",
+                t"Cannot rebase remaining {ui.change_id(revision.change_id)} because it has "
+                t"multiple visible revisions.",
+                hint=t"Resolve the divergence with {ui.cmd('jj')}, then rerun sync for this "
+                t"stack.",
             )
-    if not plan.on_trunk or not plan.survivors:
-        return
-    selected_commit_ids = {revision.commit_id for revision in plan.survivors}
-    selected_commit_ids.update(
-        item.revision.commit_id for item in plan.on_trunk if item.revision is not None
-    )
-    source_commit_ids = tuple(
-        item.revision.commit_id
-        if item.revision is not None
-        else item.candidate.submitted_baseline.commit_id
-        for item in plan.on_trunk
-    )
-    repository_paths = observe_repository_paths(
-        jj_client=context.jj_client,
-        tracked_change_ids=(),
-        descendant_of=source_commit_ids,
-        include_current_working_copy=True,
-    )
-    outside_by_commit_id = {
-        revision.commit_id: revision
-        for path in repository_paths.paths
-        for revision in path.stack.revisions
-        if revision.commit_id not in selected_commit_ids and not revision.immutable
-    }
-    outside = tuple(outside_by_commit_id.values())
-    if outside:
-        heads = ui.join(lambda revision: ui.change_id(revision.change_id), outside)
-        raise CliError(
-            t"Other local changes depend on this stack: {heads}.",
-            hint="Select each affected stack and run jj-stack sync explicitly.",
-        )
 
 
 def rewritten_retirement_blocker(
@@ -285,7 +252,11 @@ def rewritten_retirement_blocker(
             *(revision.change_id for revision in plan.survivors),
         },
     )
-    return None if recovery is None else t"another local stack still depends on it; {recovery}"
+    return (
+        None
+        if recovery is None
+        else t"another local stack still uses this merged change; {recovery}"
+    )
 
 
 def _require_no_unpublished_edits(

--- a/tests/integration/test_sync_command.py
+++ b/tests/integration/test_sync_command.py
@@ -283,6 +283,63 @@ def test_sync_preserves_unpublished_edits_to_an_active_stack_survivor(
     assert state_store.load() == state_before
 
 
+def test_sync_rebases_a_conflicted_review_before_stopping_its_update(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
+    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
+    state_store = ReviewStateStore.for_repo(repo)
+    on_trunk, reviewed = selected_stack(repo).revisions
+    reviewed_baseline = state_store.load().submitted_baselines[reviewed.change_id].commit_id
+
+    run_command(["jj", "new", on_trunk.change_id], repo)
+    commit_file(repo, "left conflict", "conflict.txt")
+    left = JjClient(repo).resolve_revision("@-")
+    run_command(["jj", "new", on_trunk.change_id], repo)
+    commit_file(repo, "right conflict", "conflict.txt")
+    right = JjClient(repo).resolve_revision("@-")
+    run_command(["jj", "new", left.commit_id, right.commit_id], repo)
+    conflict_source = JjClient(repo).resolve_revision("@")
+    assert conflict_source.conflict
+    run_command(
+        [
+            "jj",
+            "restore",
+            "--from",
+            conflict_source.commit_id,
+            "--into",
+            reviewed.change_id,
+            "conflict.txt",
+        ],
+        repo,
+    )
+    run_command(["jj", "edit", reviewed.change_id], repo)
+    run_command(["jj", "new"], repo)
+    run_command(
+        ["jj", "abandon", conflict_source.commit_id, left.commit_id, right.commit_id],
+        repo,
+    )
+    conflicted_before = JjClient(repo).resolve_revision(reviewed.change_id)
+    assert conflicted_before.conflict
+    _squash_merge_pull_request(fake_repo, 1)
+
+    exit_code = run_main(repo, config_path, "sync", reviewed.change_id)
+    captured = capsys.readouterr()
+
+    assert exit_code == 3
+    rendered = " ".join(captured.err.split())
+    assert "The local rebase is complete" in rendered
+    assert f"jj-stack submit {reviewed.change_id}" in rendered
+    conflicted_after = JjClient(repo).resolve_revision(reviewed.change_id)
+    assert conflicted_after.conflict
+    assert conflicted_after.parents == (read_remote_ref(fake_repo.git_dir, "main"),)
+    assert conflicted_after.commit_id != conflicted_before.commit_id
+    assert fake_repo.pull_requests[2].head_sha == reviewed_baseline
+    assert on_trunk.change_id in state_store.load().review_identities
+
+
 def test_sync_reports_a_closed_stack_survivor_as_a_closed_review_not_branch_drift(
     tmp_path: Path,
     monkeypatch,
@@ -623,8 +680,9 @@ def test_sync_explains_the_reported_rebase_ordering_stop_without_mutation(
 
     assert exit_code == 1
     unwrapped = " ".join(captured.err.split())
-    assert f"Reviewed {reviewed.change_id[:8]}" in unwrapped
-    assert f"unmerged local changes: {lower.change_id[:8]}" in unwrapped
+    assert f"Cannot sync reviewed {reviewed.change_id[:8]}" in unwrapped
+    assert f"unmerged local changes are its parents: {lower.change_id[:8]}" in unwrapped
+    assert "cannot decide whether those local changes belong before or after it" in unwrapped
     assert f"Submitted commit: {submitted_commit_id}" in unwrapped
     assert f"Local copy commit: {local_reviewed.commit_id}" in unwrapped
     assert f"Fetched trunk commit: {landed_commit_id}" in unwrapped
@@ -641,7 +699,7 @@ def test_sync_explains_the_reported_rebase_ordering_stop_without_mutation(
     assert fake_repo.pull_request_events == events_before
 
 
-def test_sync_preserves_a_described_working_copy_above_the_reviewed_survivor(
+def test_sync_converges_selected_path_while_a_sibling_still_needs_the_merged_change(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -649,26 +707,25 @@ def test_sync_preserves_a_described_working_copy_above_the_reviewed_survivor(
     repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     on_trunk, reviewed = selected_stack(repo).revisions
-    write_file(repo / "local-wip.txt", "keep this work\n")
-    run_command(["jj", "describe", "-m", "local WIP"], repo)
+    run_command(["jj", "new", on_trunk.change_id], repo)
+    commit_file(repo, "sibling work", "sibling.txt")
+    sibling = selected_stack(repo).head
     jj = JjClient(repo)
-    working_copy_before = jj.resolve_revision("@")
-    state_before = ReviewStateStore.for_repo(repo).load()
-    reviewed_head_before = fake_repo.pull_requests[2].head_sha
     _squash_merge_pull_request(fake_repo, 1)
 
     exit_code = run_main(repo, config_path, "sync", reviewed.change_id)
     captured = capsys.readouterr()
 
-    assert exit_code == 1
-    assert "Other local changes depend on this stack" in captured.err
-    working_copy_after = jj.resolve_revision("@")
-    assert working_copy_after.commit_id == working_copy_before.commit_id
-    assert working_copy_after.parents == (reviewed.commit_id,)
-    assert jj.resolve_revision(reviewed.change_id).commit_id == reviewed.commit_id
+    assert exit_code == 0, (captured.out, captured.err)
+    assert "another local stack still uses this merged change" in captured.out
+    assert f"jj-stack sync {sibling.change_id}" in captured.out
+    rewritten_reviewed = jj.resolve_revision(reviewed.change_id)
+    assert rewritten_reviewed.parents == (read_remote_ref(fake_repo.git_dir, "main"),)
+    assert fake_repo.pull_requests[2].head_sha == rewritten_reviewed.commit_id
+    assert fake_repo.pull_requests[2].base_ref == "main"
+    assert jj.resolve_revision(sibling.change_id).parents == (on_trunk.commit_id,)
     assert jj.resolve_revision(on_trunk.change_id).commit_id == on_trunk.commit_id
-    assert ReviewStateStore.for_repo(repo).load() == state_before
-    assert fake_repo.pull_requests[2].head_sha == reviewed_head_before
+    assert on_trunk.change_id in ReviewStateStore.for_repo(repo).load().review_identities
 
 
 def test_sync_rebases_trailing_local_work_without_creating_a_review(

--- a/tests/unit/test_trunk_evidence.py
+++ b/tests/unit/test_trunk_evidence.py
@@ -167,7 +167,7 @@ def test_finish_exit_code_separates_a_deliberate_skip_from_a_failed_write() -> N
     preserved = ReviewFinishResult(
         candidate=candidate,
         outcome="finished",
-        retirement_skip_reason="another local stack still depends on it",
+        retirement_skip_reason="another local stack still uses this merged change",
     )
     failed = ReviewFinishResult(
         candidate=candidate,


### PR DESCRIPTION
Let jj rebase conflicted survivors and selected paths with local siblings
before review publication. Keep divergence, unpublished merged edits, and
ambiguous local ordering as pre-rebase stops.

Leave conflicted reviews and shared merged tracking unchanged so later
commands recover from observed state, and explain each boundary directly in
help and user documentation.