### PR TITLE
stack: finish github-only cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ obscuring the rest of the work.
 ### AI agent integration
 
 If you use coding agents, install the bundled `jj-stack` skill so they know how to work with a
-`jj`-native stack:
+`jj` stack:
 
 ```bash
 gh skill install bos/jj-stack jj-stack
@@ -410,5 +410,5 @@ agent-written. Nevertheless, I've provided heavy oversight.
 - linear stacks only
 - one PR per change ID
 
-`jj-stack` registers every multi-PR review in GitHub's native stack model and asks GitHub to merge
+`jj-stack` registers every multi-PR review as a GitHub stack and asks GitHub to merge
 the selected prefix together. A review with one PR remains an ordinary pull request.

--- a/complexity-budget.toml
+++ b/complexity-budget.toml
@@ -53,7 +53,7 @@ governed = [
   "src/jj_stack/review/finish.py",
   "src/jj_stack/review/trunk_evidence.py",
   "src/jj_stack/review/convergence.py",
-  "src/jj_stack/review/native_sync.py",
+  "src/jj_stack/review/github_stack_sync.py",
   "src/jj_stack/review/observation.py",
 ]
 fixed_property = [

--- a/docs/daily-workflow.md
+++ b/docs/daily-workflow.md
@@ -162,7 +162,8 @@ jj-stack view --pull-request 7
 
 A full change ID and a linked PR continue to select the mutable local copy after you fetch an
 ordinary GitHub rebase merge. If two mutable copies of that change are visible, `jj-stack` stops;
-use `jj log -r 'change_id(<change-id>)'` to inspect them and choose or reconcile the copy you want.
+use `jj log -r 'change_id(<change-id>)'` to inspect them and choose or reconcile the copy you
+want.
 
 If you want to inspect several stacks in one run, pass several selectors in
 the order you want them shown:
@@ -215,7 +216,7 @@ jj-stack submit <head-change-id>
 jj-stack merge <head-change-id>
 ```
 
-A refused GitHub stack merge merges nothing at all.
+If GitHub refuses a stack merge, nothing merges.
 
 If a lower PR of your own already merged elsewhere, `merge` stops at it and names
 `jj-stack sync <head-change-id>` instead — your stack still holds a local copy of work that is
@@ -275,7 +276,7 @@ alone and prints the commits and inspection step that explain the stop.
 
 GitHub may preserve a change as it merges or create a different commit, as a squash merge does.
 `sync` handles either result without pretending the new GitHub commit is the old local change.
-If a native merge also rewrote the PRs that remain open, `sync` adopts those exact reviewed
+If a stack merge also rewrote the PRs that remain open, `sync` adopts those exact reviewed
 commits and rebases only your trailing local work above them.
 
 If reviewed work is already on fetched trunk but its local copy still follows unmerged changes,

--- a/docs/internals/backlog.md
+++ b/docs/internals/backlog.md
@@ -22,8 +22,9 @@ current core workflow._
 
 Since `jj` 0.30 the `change-id` header in Git commit objects is written and imported by default
 (`git.write-change-id-header`), so change IDs survive ordinary push/fetch round trips. Live GitHub
-experiments established that both native and ordinary rebase merge preserve it, while squash
-merge does not. Selected `sync` uses a preserved header to recognize the fetched successor;
+experiments established that both GitHub stack merges and ordinary rebase merges preserve it,
+while squash merge does not. Selected `sync` uses a preserved header to recognize the fetched
+successor;
 otherwise it retires the old local change from exact merge-result evidence without relabeling the
 commit that reached trunk or storing an alias.
 
@@ -46,9 +47,9 @@ High-level cases where this might help:
 _Benefit: medium — high value for teams that require queues, but not part of the current merge
 contract._
 
-Live evidence shows that GitHub accepts a native asynchronous stack-merge request for processing
+Live evidence shows that GitHub accepts an asynchronous stack-merge request for processing
 under a queue ruleset, then returns a terminal failure requiring the queue. The ordinary PR API
-cannot enqueue that native member either. `jj-stack` therefore reports the GitHub rejection and
+cannot enqueue that stack member either. `jj-stack` therefore reports the GitHub rejection and
 does not impose repository-wide queue or auto-merge restrictions.
 
 A future queue integration needs an explicit design for current-state observation, user-visible

--- a/docs/internals/design.md
+++ b/docs/internals/design.md
@@ -20,7 +20,7 @@ The model is small:
 The only per-change state `jj-stack` saves locally is the PR and branch attached to each change
 and the exact commit last sent for review. Everything else is observed or derived.
 
-Three goals shape the design beyond that model: stacked GitHub PRs should feel native in a `jj`
+Three goals shape the design beyond that model: stacked GitHub PRs should feel natural in a `jj`
 workflow, the tool should be easy to use, and review branch names should stay stable across
 rewrite-heavy review.
 
@@ -98,7 +98,7 @@ publish. A full change ID or linked pull request selects that unique mutable loc
 mutable copies match, selection stops rather than choosing between them. If every matching copy
 is on fetched trunk's first-parent path, logical selection stops instead of turning the sole
 immutable trunk result into an empty local stack; an explicit revision expression can still
-select a commit on trunk. The sole immutable reviewed side parent from a native merge is outside
+select a commit on trunk. The sole immutable reviewed side parent from a stack merge is outside
 that first-parent path and remains selectable until `sync`.
 
 ### Tracking
@@ -352,7 +352,7 @@ and contents, and to `@-` otherwise. Explicit empty or undescribed working-copy 
 resolves to. A full change ID or linked pull request instead selects the unique mutable copy
 outside fetched trunk's first-parent path, so fetching an ordinary rebase result does not hide
 the local path. As defined for local review stacks, the sole immutable reviewed side parent from
-a native merge remains selectable outside that path until `sync`. `relink` requires both the
+a stack merge remains selectable outside that path until `sync`. `relink` requires both the
 change and PR.
 
 Three modes deliberately reach beyond one selected stack:
@@ -626,7 +626,7 @@ One repository therefore cannot report complete from one command and incomplete 
 Because a divergent change has several visible copies, every change-ID query selects all of them
 rather than resolving a bare change-ID symbol, which `jj` rejects as ambiguous.
 
-`view` and `submit` render stack rows through the user's native `jj log` formatting. `--json`
+`view` and `submit` render stack rows through the user's `jj log` formatting. `--json`
 follows [`docs/json-output.schema.json`](../json-output.schema.json) and exposes no cache state,
 raw remote targets, or tracking records.
 
@@ -698,7 +698,7 @@ Supported:
 - linear local review stacks
 - visible mutable review changes
 - one PR per review change
-- native GitHub stacks for every multi-PR review
+- GitHub stacks for every multi-PR review
 
 Unsupported:
 

--- a/docs/internals/distributed-state.md
+++ b/docs/internals/distributed-state.md
@@ -20,11 +20,11 @@ have defined behavior but no dedicated current scenario.
    `jj-stack` atomic leased pushes, by anyone else's pushes (a teammate merging to `main`, an
    agent pushing a branch with plain git), and by branch deletion from the GitHub UI or `gh`.
 3. **GitHub review state** — PRs with head/base refs, open/closed/merged state, draft
-   flags, reviews, labels, comments, plus native stack resources with ordered membership
+   flags, reviews, labels, comments, plus GitHub stack resources with ordered membership
    and historical merge results. Moved by `jj-stack` mutations, by humans and agents
    through the UI or `gh`, and by GitHub itself: it auto-closes an open PR whose head
    becomes reachable from its base, closes PRs whose head branch is deleted, and records
-   native stack transitions.
+   GitHub stack transitions.
 4. **Tracking store** — the `ReviewIdentity` and `SubmittedBaseline` records described in
    [design.md](design.md). Moved by the commands that design.md allows to change an identity or
    advance a baseline; status observation never writes any of them.

--- a/docs/internals/implementation-strategy.md
+++ b/docs/internals/implementation-strategy.md
@@ -85,7 +85,7 @@ The bundled agent skill in `skills/jj-stack/` is installed separately from the e
 - discovers and caches the working invocation for a repository
 - uses `list --json` and `view --json` to recognize locally managed reviews
 - routes structural PR and review-branch changes through `jj-stack`, except for the explicit
-  `gh stack unstack` repair that dissolves one native GitHub stack before separate submissions
+  `gh stack unstack` repair that dissolves one GitHub stack before separate submissions
 
 Built-in help and the user guide own the command and alias inventory.
 
@@ -112,15 +112,15 @@ src/
     ...
     models/
     commands/
-      _native_stack_safety.py
+      _github_stack_safety.py
       cleanup/
       merge/
       submit/
-        native.py
+        github_stack.py
     jj/
     github/
     review/
-      native_sync.py
+      github_stack_sync.py
     state/
 tests/
   unit/
@@ -204,8 +204,8 @@ is that change; none, or more than one, is ambiguous and fails closed.
 
 Planning is a layering rule rather than a separate package. Shared classification lives under
 `review/`, while command-specific planning lives beside the command, such as
-`commands/merge/plan.py`, `commands/merge/native.py`, and the submit modules. Given typed local
-and remote state, it decides:
+`commands/merge/plan.py`, `commands/merge/github_stack.py`, and the submit modules. Given typed
+local and remote state, it decides:
 
 - which changes are reviewable
 - which stable remote branch each change should use
@@ -229,7 +229,7 @@ Selected path planning has a smaller pure boundary in `review/path.py`. The sele
 observes selector copies, the ordinary first-parent chain, fetched-trunk membership, and tracking
 annotations in one bounded `jj` query. For a full change ID or linked pull request, the pure
 projection prefers the unique mutable local copy outside fetched trunk's first-parent path and
-stops when matches remain only on that path. A sole immutable reviewed side parent from a native
+stops when matches remain only on that path. A sole immutable reviewed side parent from a stack
 merge remains outside the path and selectable until `sync`. The projection returns one
 parent-connected `LocalStack`. Tracking annotates that path and cannot create or reorder it.
 Command-owned GitHub identity, merge evidence, and mutation policy stay outside the projection.
@@ -247,8 +247,8 @@ change-ID-tuple deduplication. Tracking only annotates the paths after their top
 
 Thin `httpxyz` wrapper plus typed `pydantic` models. Knows how to fetch PR state, batch PR
 lookup by PR number or known head branch, create PRs, update PRs, assign reviewers and labels,
-manage overview comments, list/create/append/unstack native resources, submit and
-poll asynchronous native merges, and handle endpoint-specific pagination or retry.
+manage overview comments, list/create/append/unstack GitHub stack resources, submit and
+poll asynchronous stack merges, and handle endpoint-specific pagination or retry.
 
 When endpoint semantics allow it, the client and command layers prefer batched or
 bounded-parallel GitHub work over one-request-per-item serial loops. Ordering
@@ -271,15 +271,15 @@ Property families and their assertions live in [property-testing.md](property-te
 managed comment, falling back to REST pagination only for PRs whose first comment page
 is incomplete.
 
-Native group merge is `PUT /repos/{owner}/{repo}/pulls/{target_pr}/merge-async`, whose body
+Stack merge is `PUT /repos/{owner}/{repo}/pulls/{target_pr}/merge-async`, whose body
 carries `merge_method` and the `sha` of the exact target PR head. An accepted request returns an
 operation UUID that the client polls to a terminal state. A concurrent `409` is decoded so a
 matching pending request can be distinguished from an unrelated conflict, but its UUID is never
 adopted, because the response body does not identify the target PR. The merge policy those
 requests serve is specified in [design.md](design.md).
 
-The client reports endpoint results but does not decide stack topology, branch naming, or native
-membership policy.
+The client reports endpoint results but does not decide stack topology, branch naming, or GitHub
+stack membership policy.
 
 ### Config and tracking state
 
@@ -308,8 +308,8 @@ The repo state directory also contains the operation lock files:
 
 Mutating commands hold the lock through their mutation phase. Bootstrap, validation, interactive
 selection, and final rendering may happen outside it. The lock is process coordination only. The
-state directory contains no operation journal, merge note, phase, selector, path, native resource
-ID, or recovery checkpoint.
+state directory contains no operation journal, merge note, phase, selector, path, GitHub stack
+resource ID, or recovery checkpoint.
 
 Merge and recovery share current-state observation rather than a durable operation state
 machine:
@@ -321,15 +321,15 @@ machine:
   merge result
 - `review/finish.py` finalizes merged PRs and removes saved tracking
 - `review/convergence.py` checks whether another visible stack still needs that tracking
-- `review/native_sync.py` validates historical native members and survivor transitions
-- `commands/_native_stack_safety.py` owns the one native membership decision:
-  `selected_native_stack` resolves the single resource a selected review set belongs to and
+- `review/github_stack_sync.py` validates historical stack members and survivor transitions
+- `commands/_github_stack_safety.py` owns the one stack membership decision:
+  `selected_github_stack` resolves the single resource a selected review set belongs to and
   requires every active member of it to be selected. `submit`, `merge`, selected `sync`,
   `unstack`, and cleanup call it and derive their own consequence from the resource it returns;
   none of them repeats the decision
 
-Selected native sync uses the same fixed temporary attachment as checkout for one additional
-purpose: after a native merge rewrites the active suffix, it validates every active raw Git commit
+Selected stack sync uses the same fixed temporary attachment as checkout for one additional
+purpose: after a stack merge rewrites the active suffix, it validates every active raw Git commit
 and parent, reobserves the whole branch set, then imports the exact top into jj. It rebases only
 trailing local descendants, abandons the replaced local active copies, and advances every adopted
 baseline together through the state store's existing pair compare-and-swap. It
@@ -372,7 +372,7 @@ eligibility checks instead of observing those facts again through a command-spec
 
 Repository-wide cleanup is one lifecycle-driven pass over complete identity/baseline pairs.
 It observes the exact saved PR, prepares branch and comment cleanup for a closed or merged match,
-and rereads the PR, its unique head claim, open base-ref dependents, remote ref, native
+and rereads the PR, its unique head claim, open base-ref dependents, remote ref, GitHub stack
 membership, and tracking records at their mutation boundaries. Selected cleanup processes the
 observed stack head-to-base. A dry run may omit only dependents that an earlier selected action
 would close; actual cleanup never omits a live dependent. Local jj descendants remain
@@ -457,8 +457,8 @@ Implemented local coverage includes:
 - unit tests for parsing, planning, and model behavior
 - local integration tests against the fake GitHub server and a real backing Git repo
 - five fixed generated/property cases that replay the integration harness in the default suite
-- focused merge and recovery cases, including native atomic failure, partial survivor rewrites,
-  terminal retry, and single-PR merge topology
+- focused merge and recovery cases, including atomic stack-merge failure, partial survivor
+  rewrites, terminal retry, and single-PR merge topology
 
 Local tests are the default.
 
@@ -514,10 +514,10 @@ Rules:
 The fake server owns a real Git repo because many assertions are about actual remote
 branch state, not just JSON responses.
 
-Its native endpoints model ordered resource membership, historical merged prefixes, exact active
-suffix unstacking, create/append admission, and asynchronous merge submission and polling. The
-merge fixtures cover atomic failure, partial survivor rewrites, and terminal retry. They remain
-bounded contracts rather than a general native-stack emulator.
+Its GitHub stack endpoints model ordered resource membership, historical merged prefixes, exact
+active suffix unstacking, create/append admission, and asynchronous merge submission and
+polling. The merge fixtures cover atomic failure, partial survivor rewrites, and terminal retry.
+They remain bounded contracts rather than a general GitHub stack emulator.
 
 We use FastAPI for the fake server unless Starlette later proves to offer a clear
 concrete advantage for this test harness.
@@ -525,7 +525,7 @@ concrete advantage for this test harness.
 ## Live GitHub evidence
 
 There is no credentialed live suite. Approved disposable-repository experiments established the
-native create, append, unstack, historical-member, asynchronous merge, queue-rejection,
+stack creation, append, unstack, historical-member, asynchronous merge, queue-rejection,
 merge-method, expected-head, and Git `change-id` contracts modeled by the fake. Future live checks
 still require explicit credentials, a disposable repository, and separate approval for external
 mutations.

--- a/docs/internals/property-testing.md
+++ b/docs/internals/property-testing.md
@@ -84,7 +84,7 @@ Replay follows the same shape for every scenario:
 6. Apply the scenario operations with real `jj` commands.
 7. Rediscover the selected live stack from the current DAG and assert that its
    `change_id` order matches the scenario model. Subjects are diagnostics only.
-8. Dissolve any old native GitHub stack that includes active reviews outside the selected path,
+8. Dissolve any old GitHub stack that includes active reviews outside the selected path,
    or when the selection combines more than one old GitHub stack. This models the exact
    `gh stack unstack` recovery named by `submit`.
 9. Run `submit` again on the new stack head.
@@ -168,13 +168,14 @@ unclassified error. Exact diagnostic wording stays out of scope.
 
 Merge and post-merge convergence use focused deterministic integration tests rather than the
 submit property generator. The tested boundaries include exact submitted-head validation,
-bottom-prefix selection, draft and closed boundaries, native atomic failure, partial native
-survivor rewrites, terminal retry, historical-member cleanup, and selected or repository-wide
-sync eligibility.
+bottom-prefix selection, draft and closed boundaries, atomic stack-merge failure, partial stack
+merge survivor rewrites, terminal retry, historical-member cleanup, and selected or
+repository-wide sync eligibility.
 
-The native tests assert both final Git and PR state and the significant API events. A terminal
-native failure changes nothing. A successful partial request may change survivor heads and bases,
-but `merge` does not rewrite local history; selected `sync` validates and converges that remote
+The stack-merge tests assert both final Git and PR state and the significant API events. A
+terminal stack-merge failure changes nothing. A successful partial request may change survivor
+heads and bases, but `merge` does not rewrite local history; selected `sync` validates and
+converges that remote
 transition. These are bounded command contracts, not generated merge property families or a
 durable recovery state machine.
 

--- a/docs/mental-model.md
+++ b/docs/mental-model.md
@@ -61,7 +61,7 @@ request." `jj-stack` creates review branches only because GitHub requires them. 
 a transport layer; the main authoring model is still local `jj` history.
 
 A review first submitted with one change remains one ordinary PR. Once the review has at least
-two PRs, `jj-stack` registers their order with GitHub's native stack feature. After lower PRs
+two PRs, `jj-stack` registers their order with GitHub's stack feature. After lower PRs
 merge, GitHub may keep them in that group as history, so the remaining PR can still belong to the
 existing group. The local DAG decides which changes belong together; the grouping on GitHub
 follows from it.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -136,7 +136,7 @@ jj-stack sync <head-change-id>
 changes above the current `trunk()`, and updates only PRs that already exist for them. Use
 `jj-stack sync --dry-run <head-change-id>` first to preview merged changes and any cleanup or
 rebase. If a rebase is needed, its later PR-update plan is available only after you run `sync`.
-When a native merge rewrote the PRs that remain open, `sync` adopts those exact reviewed commits
+When a stack merge rewrote the PRs that remain open, `sync` adopts those exact reviewed commits
 and rebases only trailing local work above them. It leaves other stacks and unreviewed trailing
 changes alone.
 
@@ -448,7 +448,7 @@ each time.
 - `sync --all`: preview with `jj-stack sync --all --dry-run`, then run
   `jj-stack sync --all`.
 - `merge`: rerun the same explicit selector and merge method. A matching request still in progress
-  asks you to wait; a completed native request is observed on retry.
+  asks you to wait; a completed stack-merge request is observed on retry.
 
 `jj-stack sync <head-change-id>` handles commits rewritten by GitHub while keeping a review
 branch that a PR above still needs. `sync --all` checks independently tracked exact commits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "jj-stack"
 version = "0.1.0"
-description = "JJ-native stacked GitHub review tooling"
+description = "Stacked GitHub review tooling for jj"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.14"

--- a/skills/jj-stack/SKILL.md
+++ b/skills/jj-stack/SKILL.md
@@ -2,7 +2,7 @@
 name: jj-stack
 license: Apache-2.0
 description: >
-  Manage jj-native stacked GitHub review with jj-stack. Use when inspecting,
+  Manage stacked GitHub review for jj with jj-stack. Use when inspecting,
   creating, submitting, refreshing, revising, merging, cleaning up, or
   recovering stacked pull requests for local jj changes, and before mutating
   any GitHub pull request or branch with gh or the GitHub API in a jj repo.
@@ -157,7 +157,7 @@ that is incomplete or needs attention (the output is still valid — read it);
 
 - `merge` rejected by GitHub: read the reported check, conflict, queue,
   policy, or access reason, fix it, and rerun the same explicit
-  command. A native terminal failure merges nothing. A matching request already
+  command. A terminal stack-merge failure merges nothing. A matching request already
   pending should be allowed to finish, then observed by rerunning the same target
   and method.
 - Interrupted command: `view`, then rerun with an explicit change ID, revset,

--- a/src/jj_stack/__init__.py
+++ b/src/jj_stack/__init__.py
@@ -1,4 +1,4 @@
-"""JJ-native stacked GitHub review tooling."""
+"""Stacked GitHub review tooling for jj."""
 
 from importlib.metadata import PackageNotFoundError, version
 

--- a/src/jj_stack/commands/_close_actions.py
+++ b/src/jj_stack/commands/_close_actions.py
@@ -9,7 +9,7 @@ from typing import Literal
 import jj_stack.console as console
 import jj_stack.ui as ui
 from jj_stack.bootstrap import CommandContext
-from jj_stack.commands._native_stack_safety import GithubStackSelection
+from jj_stack.commands._github_stack_safety import GithubStackSelection
 from jj_stack.errors import CliError
 from jj_stack.github.client import GithubClient, GithubClientError
 from jj_stack.github.overview_comments import (
@@ -491,12 +491,12 @@ def plan_review_cleanup(
     return pull_request, update, None
 
 
-async def native_stack_cleanup_blocker(
+async def github_stack_cleanup_blocker(
     *,
     github_client: GithubClient,
     pull_number: int,
 ) -> CloseAction | None:
-    """Fail closed when current native membership still needs a review branch."""
+    """Fail closed when current stack membership still needs a review branch."""
 
     try:
         await GithubStackSelection(github_client, (pull_number,)).require_unstacked()
@@ -573,7 +573,7 @@ async def prepare_current_review_cleanup(
     )
     if blocker is not None:
         return None, blocker
-    blocker = await native_stack_cleanup_blocker(
+    blocker = await github_stack_cleanup_blocker(
         github_client=github_client,
         pull_number=review_identity.pr_number,
     )

--- a/src/jj_stack/commands/_github_stack_safety.py
+++ b/src/jj_stack/commands/_github_stack_safety.py
@@ -1,4 +1,4 @@
-"""Mutation guards for GitHub native stack resources."""
+"""Mutation guards for GitHub stack resources."""
 
 from __future__ import annotations
 
@@ -11,12 +11,12 @@ from jj_stack.github.client import GithubClient, GithubClientError
 from jj_stack.models.github import GithubStack
 
 
-def selected_native_stack(
+def selected_github_stack(
     *,
     selected_pull_numbers: Collection[int],
     stacks: Sequence[GithubStack],
 ) -> GithubStack | None:
-    """Return the one native GitHub stack the selected pull requests belong to.
+    """Return the one GitHub stack the selected pull requests belong to.
 
     The selection may overlap at most one resource, and every active member of that resource
     must be selected. A merged prefix GitHub retains is always valid, so a resource the selection
@@ -41,7 +41,7 @@ def selected_native_stack(
     if len(dissolvable) > 1:
         numbers = tuple(sorted(stack.number for stack in dissolvable))
         raise CliError(
-            t"The selected reviews belong to native GitHub stacks "
+            t"The selected reviews belong to GitHub stacks "
             t"{ui.join(lambda number: f'#{number}', numbers)}.",
             hint=t"Run {ui.join(lambda number: ui.cmd(f'gh stack unstack {number}'), numbers)}, "
             t"then retry.",
@@ -49,7 +49,7 @@ def selected_native_stack(
     if not dissolvable and len(overlapping) > 1:
         numbers = tuple(sorted(stack.number for stack in overlapping))
         raise CliError(
-            t"The selected reviews are merged members of native GitHub stacks "
+            t"The selected reviews are merged members of GitHub stacks "
             t"{ui.join(lambda number: f'#{number}', numbers)}.",
             hint="Select changes belonging to one of those stacks, then retry.",
         )
@@ -70,18 +70,18 @@ def selected_native_stack(
 
 @dataclass(frozen=True, slots=True)
 class GithubStackSelection:
-    """Live native membership for one exact ordered PR selection."""
+    """Live stack membership for one exact ordered PR selection."""
 
     github_client: GithubClient
     pull_numbers: tuple[int, ...]
 
     async def observe(self) -> tuple[GithubStack, ...]:
-        """Return the current complete native resources."""
+        """Return the current complete GitHub stack resources."""
 
         try:
             return await self.github_client.list_stacks()
         except GithubClientError as error:
-            raise CliError("Could not inspect native GitHub stack membership.") from error
+            raise CliError("Could not inspect GitHub stack membership.") from error
 
     async def active_stacks(self) -> tuple[GithubStack, ...]:
         """Return the resources in which a selected review is still an active member.
@@ -145,7 +145,7 @@ class GithubStackSelection:
         stacks = observed if observed is not None else await self.active_stacks()
         if not stacks:
             return None
-        stack = selected_native_stack(selected_pull_numbers=self.pull_numbers, stacks=stacks)
+        stack = selected_github_stack(selected_pull_numbers=self.pull_numbers, stacks=stacks)
         assert stack is not None
         try:
             current = await self.github_client.get_stack(stack_number=stack.number)

--- a/src/jj_stack/commands/cleanup/command.py
+++ b/src/jj_stack/commands/cleanup/command.py
@@ -29,7 +29,7 @@ from jj_stack.commands._close_actions import (
     check_current_review_cleanup,
     check_tracked_review,
     find_overview_comment,
-    native_stack_cleanup_blocker,
+    github_stack_cleanup_blocker,
     plan_review_cleanup,
 )
 from jj_stack.commands._fetch_isolation import report_fetch_isolation
@@ -335,12 +335,12 @@ async def _cleanup_tracked_review(
                 )
             )
         return
-    native_blocker = await native_stack_cleanup_blocker(
+    stack_blocker = await github_stack_cleanup_blocker(
         github_client=github_client,
         pull_number=identity.pr_number,
     )
-    if native_blocker is not None:
-        record_action(_cleanup_action(native_blocker))
+    if stack_blocker is not None:
+        record_action(_cleanup_action(stack_blocker))
         return
     overview_lookup = await _preflight_cleanup_overview_comment(
         github_client=github_client,

--- a/src/jj_stack/commands/close_orphan.py
+++ b/src/jj_stack/commands/close_orphan.py
@@ -22,7 +22,7 @@ from jj_stack.commands._close_actions import (
     plan_review_cleanup,
 )
 from jj_stack.commands._fetch_isolation import report_fetch_isolation
-from jj_stack.commands._native_stack_safety import GithubStackSelection
+from jj_stack.commands._github_stack_safety import GithubStackSelection
 from jj_stack.errors import CliError
 from jj_stack.github.client import GithubClient, GithubClientError, build_github_client
 from jj_stack.github.error_messages import github_target_unavailable_messages
@@ -266,7 +266,7 @@ async def _mutate_orphan_close(
 ) -> None:
     """Apply the preflighted orphan mutations in dependency order."""
 
-    pull_request = await _dissolve_orphan_native_stack(
+    pull_request = await _dissolve_orphan_github_stack(
         github_client=github_client,
         prepared=prepared,
         recorder=recorder,
@@ -309,14 +309,14 @@ async def _mutate_orphan_close(
         )
 
 
-async def _dissolve_orphan_native_stack(
+async def _dissolve_orphan_github_stack(
     *,
     github_client: GithubClient,
     prepared: _PreparedOrphanClose,
     recorder: ActionRecorder[CloseAction],
     run: _OrphanCloseRun,
 ) -> GithubPullRequest | None:
-    """Recheck and dissolve native membership when orphan cleanup needs it."""
+    """Recheck and dissolve stack membership when orphan cleanup needs it."""
 
     if run.dry_run:
         pull_request = prepared.initial_pull_request
@@ -341,7 +341,7 @@ async def _dissolve_orphan_native_stack(
         (prepared.review_identity.pr_number,),
     )
     try:
-        native_stack = (
+        github_stack = (
             await selection.recheck_active_suffix()
             if run.dry_run
             else await selection.dissolve_exact()
@@ -349,11 +349,11 @@ async def _dissolve_orphan_native_stack(
     except CliError as error:
         recorder.record(CloseAction(kind="GitHub stack", body=str(error), status="blocked"))
         return None
-    if native_stack is not None:
+    if github_stack is not None:
         recorder.record(
             CloseAction(
                 kind="GitHub stack",
-                body=t"dissolve GitHub stack #{native_stack.number}",
+                body=t"dissolve GitHub stack #{github_stack.number}",
                 status="planned" if run.dry_run else "applied",
             )
         )

--- a/src/jj_stack/commands/merge/command.py
+++ b/src/jj_stack/commands/merge/command.py
@@ -4,7 +4,7 @@ Candidates are the consecutive open, non-draft pull requests from the bottom. Ea
 match the exact commit last submitted; GitHub decides whether reviews, checks, conflicts, and
 repository rules allow the merge.
 
-GitHub merges a multi-PR prefix together through its native stack API. A one-PR review uses the
+GitHub merges a multi-PR prefix together through its stack API. A one-PR review uses the
 ordinary pull-request API. This command does not update local history or remove review state; run
 the printed `jj-stack sync` command after GitHub merges anything.
 
@@ -23,7 +23,7 @@ import jj_stack.console as console
 import jj_stack.ui as ui
 from jj_stack.bootstrap import CommandContext, bootstrap_context
 from jj_stack.commands._fetch_isolation import report_fetch_isolation
-from jj_stack.commands._native_stack_safety import GithubStackSelection
+from jj_stack.commands._github_stack_safety import GithubStackSelection
 from jj_stack.config import MergeMethod
 from jj_stack.errors import CliError
 from jj_stack.github.client import GithubClientError, build_github_client
@@ -39,8 +39,12 @@ from jj_stack.review.status import prepare_status
 from jj_stack.state.operation_lock import acquire_operation_lock
 
 from .execute import execute_single_pull_request_merge
+from .github_stack import (
+    build_github_stack_merge_plan,
+    check_github_stack_merge,
+    execute_github_stack_merge,
+)
 from .models import MergeExecutionInputs, MergeResult, PreparedMerge
-from .native import build_native_merge_plan, check_native_merge, execute_native_merge
 from .plan import build_merge_plan
 from .render import print_merge_result
 
@@ -236,7 +240,11 @@ async def _stream_merge_async(
             tuple(revision.identity.pr_number for revision in plan.reviewed_revisions),
         )
         stacks = await selection.observe()
-        native = build_native_merge_plan(plan, stacks, prepared_merge.target_change_id)
+        github_stack_merge = build_github_stack_merge_plan(
+            plan,
+            stacks,
+            prepared_merge.target_change_id,
+        )
         execution = MergeExecutionInputs(
             context=prepared_merge.context,
             remote_name=remote.name,
@@ -245,16 +253,18 @@ async def _stream_merge_async(
             trunk_subject=prepared.stack.trunk.subject,
         )
         if prepared_merge.dry_run:
-            if native is not None:
-                await check_native_merge(execution, github_client, native)
-                return execution.result(actions=(native.action(resolved_merge_method),))
+            if github_stack_merge is not None:
+                await check_github_stack_merge(execution, github_client, github_stack_merge)
+                return execution.result(
+                    actions=(github_stack_merge.action(resolved_merge_method),)
+                )
             return execution.result(actions=plan.planned_actions())
-        if native is not None:
-            return await execute_native_merge(
+        if github_stack_merge is not None:
+            return await execute_github_stack_merge(
                 execution=execution,
                 github=github_client,
                 merge_method=resolved_merge_method,
-                native=native,
+                github_stack_merge=github_stack_merge,
             )
         return await execute_single_pull_request_merge(
             execution=execution,

--- a/src/jj_stack/commands/merge/github_stack.py
+++ b/src/jj_stack/commands/merge/github_stack.py
@@ -1,4 +1,4 @@
-"""Native asynchronous merge policy."""
+"""GitHub stack merge policy."""
 
 from __future__ import annotations
 
@@ -6,10 +6,10 @@ import asyncio
 from dataclasses import dataclass, replace
 
 import jj_stack.ui as ui
-from jj_stack.commands._native_stack_safety import selected_native_stack
+from jj_stack.commands._github_stack_safety import selected_github_stack
 from jj_stack.errors import CliError
 from jj_stack.github.client import GithubClient, GithubClientError
-from jj_stack.models.github import GithubAsyncMerge, GithubStack
+from jj_stack.models.github import GithubStack, GithubStackMerge
 from jj_stack.review.observation import observe_reviews
 from jj_stack.ui import Message
 
@@ -18,7 +18,7 @@ from .preconditions import merge_precondition_error
 
 
 @dataclass(frozen=True, slots=True)
-class NativeMergePlan:
+class GithubStackMergePlan:
     resource: GithubStack
     active: tuple[MergeRevision, ...]
     planned: tuple[MergeRevision, ...]
@@ -31,26 +31,26 @@ class NativeMergePlan:
     def action(self, method: str) -> MergeAction:
         numbers = ", ".join(f"#{revision.identity.pr_number}" for revision in self.planned)
         return MergeAction(
-            kind="native stack request",
-            body=t"PUT one {ui.cmd(method)} native prefix for PRs {numbers} through "
+            kind="GitHub stack merge request",
+            body=t"PUT one {ui.cmd(method)} GitHub stack prefix for PRs {numbers} through "
             t"commit {ui.commit_id(self.target.commit_id)}",
             status="planned",
         )
 
 
-def build_native_merge_plan(
+def build_github_stack_merge_plan(
     merge_plan: MergePlan,
     stacks: tuple[GithubStack, ...],
     target_change_id: str | None,
-) -> NativeMergePlan | None:
+) -> GithubStackMergePlan | None:
     by_pull = {
         revision.identity.pr_number: revision for revision in merge_plan.reviewed_revisions
     }
-    resource = selected_native_stack(selected_pull_numbers=tuple(by_pull), stacks=stacks)
+    resource = selected_github_stack(selected_pull_numbers=tuple(by_pull), stacks=stacks)
     if resource is None:
         if len(by_pull) > 1:
             raise CliError(
-                "GitHub did not report a native stack for this multi-PR review.",
+                "GitHub did not report a stack for this multi-PR review.",
                 hint=t"Run {ui.cmd('submit')} before merging.",
             )
         return None
@@ -65,7 +65,7 @@ def build_native_merge_plan(
                 hint=t"Run {ui.cmd('jj-stack submit')} so the stack matches this path, "
                 t"then retry.",
             )
-        return NativeMergePlan(resource, active, merge_plan.planned_revisions)
+        return GithubStackMergePlan(resource, active, merge_plan.planned_revisions)
     historical = tuple(
         by_pull[number]
         for number in resource.historical_pull_request_numbers
@@ -77,50 +77,55 @@ def build_native_merge_plan(
         stop = change_ids.index(target_change_id) + 1
     if not stop or merge_plan.reviewed_revisions[: len(historical)] != historical:
         return None
-    return NativeMergePlan(resource, active, historical[:stop], terminal_retry=True)
+    return GithubStackMergePlan(resource, active, historical[:stop], terminal_retry=True)
 
 
-async def execute_native_merge(
+async def execute_github_stack_merge(
     *,
     execution: MergeExecutionInputs,
     github: GithubClient,
     merge_method: str,
-    native: NativeMergePlan,
+    github_stack_merge: GithubStackMergePlan,
 ) -> MergeResult:
-    await check_native_merge(execution, github, native)
+    await check_github_stack_merge(execution, github, github_stack_merge)
     try:
         submission = await github.submit_stack_merge(
-            expected_head_sha=native.target.commit_id,
+            expected_head_sha=github_stack_merge.target.commit_id,
             merge_method=merge_method,
-            pull_number=native.target.identity.pr_number,
+            pull_number=github_stack_merge.target.identity.pr_number,
         )
     except GithubClientError as error:
         raise CliError(
-            t"Could not request native merge through PR #{native.target.identity.pr_number}.",
+            t"Could not request GitHub stack merge through "
+            t"PR #{github_stack_merge.target.identity.pr_number}.",
             hint="Resolve the GitHub error above, then rerun merge.",
         ) from error
     if submission.already_pending:
         details = submission.result.details
         matching = (
-            details.expected_head_sha == native.target.commit_id
+            details.expected_head_sha == github_stack_merge.target.commit_id
             and details.merge_method == merge_method
         )
-        return _result(
+        return _blocked_result(
             execution,
-            native,
+            github_stack_merge,
             reason=(
                 "a matching request is already pending; wait and rerun merge"
                 if matching
-                else "another native merge request is already pending"
+                else "another GitHub stack merge request is already pending"
             ),
         )
-    terminal = await _terminal(github, submission.result, native.target.identity.pr_number)
+    terminal = await _terminal(
+        github,
+        submission.result,
+        github_stack_merge.target.identity.pr_number,
+    )
     if terminal.status == "failed":
         reason = terminal.details.message or "GitHub did not provide a failure reason"
         submit = ui.cmd(f"jj-stack submit {execution.selected_revset}")
-        return _result(
+        return _blocked_result(
             execution,
-            native,
+            github_stack_merge,
             reason=t"GitHub reports nothing merged: {reason}; if the stack conflicts with "
             t"{ui.bookmark(execution.trunk_branch)}, rebase onto {ui.revset('trunk()')}, resolve "
             t"the conflict, and run {submit} before merging again; if a check or repository rule "
@@ -128,25 +133,33 @@ async def execute_native_merge(
         )
     if terminal.status != "merged" or terminal.details.sha is None:
         raise CliError(
-            "GitHub reported the native merge as merged without a final trunk commit.",
+            "GitHub reported the stack merge as merged without a final trunk commit.",
             hint=t"Run {ui.cmd('jj-stack sync')} to reconcile whatever GitHub actually did.",
         )
-    return _result(
+    return _applied_result(
         execution,
-        native,
+        github_stack_merge,
         final_sha=terminal.details.sha,
         merge_method=merge_method,
     )
 
 
-async def check_native_merge(
+async def check_github_stack_merge(
     execution: MergeExecutionInputs,
     github: GithubClient,
-    native: NativeMergePlan,
+    github_stack_merge: GithubStackMergePlan,
 ) -> None:
-    resource = await github.get_stack(stack_number=native.resource.number)
-    revisions = native.planned if native.terminal_retry else native.active
-    inactive = revisions if native.terminal_retry else native.active[len(native.planned) :]
+    resource = await github.get_stack(stack_number=github_stack_merge.resource.number)
+    revisions = (
+        github_stack_merge.planned
+        if github_stack_merge.terminal_retry
+        else github_stack_merge.active
+    )
+    inactive = (
+        revisions
+        if github_stack_merge.terminal_retry
+        else github_stack_merge.active[len(github_stack_merge.planned) :]
+    )
     observation = await observe_reviews(
         change_ids=tuple(revision.change_id for revision in revisions),
         context=execution.context,
@@ -163,7 +176,7 @@ async def check_native_merge(
         remote_name=execution.remote_name,
         revisions=revisions,
     )
-    if error or resource.pull_request_numbers != native.resource.pull_request_numbers:
+    if error or resource.pull_request_numbers != github_stack_merge.resource.pull_request_numbers:
         raise CliError(
             error or t"GitHub stack #{resource.number} changed after planning.",
             hint=t"Rerun {ui.cmd('jj-stack merge')} to plan against the current stack.",
@@ -172,13 +185,13 @@ async def check_native_merge(
 
 async def _terminal(
     github: GithubClient,
-    result: GithubAsyncMerge,
+    result: GithubStackMerge,
     pull_number: int,
-) -> GithubAsyncMerge:
+) -> GithubStackMerge:
     operation_uuid = result.details.uuid
     if result.status == "pending" and operation_uuid is None:
         raise CliError(
-            "GitHub accepted the native merge without an operation ID to follow.",
+            "GitHub accepted the stack merge without an operation ID to follow.",
             hint=t"Run {ui.cmd('jj-stack sync')} to see whether the merge completed.",
         )
     while result.status == "pending":
@@ -191,26 +204,32 @@ async def _terminal(
     return result
 
 
-def _result(
+def _blocked_result(
     execution: MergeExecutionInputs,
-    native: NativeMergePlan,
+    github_stack_merge: GithubStackMergePlan,
     *,
-    final_sha: str | None = None,
-    merge_method: str | None = None,
-    reason: Message | None = None,
+    reason: Message,
 ) -> MergeResult:
-    if reason is not None:
-        return execution.result(
-            actions=(
-                MergeAction(
-                    kind="boundary",
-                    body=t"at native stack #{native.resource.number}: {reason}",
-                    status="blocked",
-                ),
-            )
-        )
     return execution.result(
-        actions=(replace(native.action(merge_method or ""), status="applied"),),
+        actions=(
+            MergeAction(
+                kind="boundary",
+                body=t"at GitHub stack #{github_stack_merge.resource.number}: {reason}",
+                status="blocked",
+            ),
+        )
+    )
+
+
+def _applied_result(
+    execution: MergeExecutionInputs,
+    github_stack_merge: GithubStackMergePlan,
+    *,
+    final_sha: str,
+    merge_method: str,
+) -> MergeResult:
+    return execution.result(
+        actions=(replace(github_stack_merge.action(merge_method), status="applied"),),
         final_trunk_commit_id=final_sha,
-        merged_change_ids=tuple(revision.change_id for revision in native.planned),
+        merged_change_ids=tuple(revision.change_id for revision in github_stack_merge.planned),
     )

--- a/src/jj_stack/commands/submit/command.py
+++ b/src/jj_stack/commands/submit/command.py
@@ -45,7 +45,7 @@ import jj_stack.console as console
 import jj_stack.ui as ui
 from jj_stack.bootstrap import CommandContext, bootstrap_context
 from jj_stack.commands._fetch_isolation import report_fetch_isolation
-from jj_stack.commands._native_stack_safety import GithubStackSelection
+from jj_stack.commands._github_stack_safety import GithubStackSelection
 from jj_stack.concurrency import DEFAULT_BOUNDED_CONCURRENCY
 from jj_stack.errors import CliError
 from jj_stack.formatting import short_change_id
@@ -75,6 +75,12 @@ from jj_stack.state.operation_lock import acquire_operation_lock
 
 from . import auto_close
 from .auto_close import retarget_review_bases_before_branch_push
+from .github_stack import (
+    GithubStackPlan,
+    apply_github_stack_plan,
+    plan_github_stack,
+    require_current_github_stack_plan,
+)
 from .inputs import prepare_submit_inputs
 from .models import (
     GeneratedDescription,
@@ -87,7 +93,6 @@ from .models import (
     SubmitResult,
     SubmittedRevision,
 )
-from .native import NativeStackPlan, apply_native_stack_plan, plan_native_stack
 from .overview_comments import stack_overview_comment_bodies, sync_stack_overview_comments
 from .pull_requests import (
     discover_pull_requests_by_branch,
@@ -536,7 +541,7 @@ async def run_submit_async(
             else None
             for pending in pending_syncs
         )
-        native_plan = plan_native_stack(
+        github_stack_plan = plan_github_stack(
             desired=desired_pull_numbers,
             observed_stacks=observed_stacks,
             pull_numbers_requiring_base_update={
@@ -546,14 +551,19 @@ async def run_submit_async(
                 and (pull_request.base.ref != pending.base_branch or pending in retarget_syncs)
             },
         )
-        if native_plan.action == "replace" and not dry_run:
-            assert (native_stack := native_plan.affected_stack) is not None
+        if github_stack_plan.action == "replace" and not dry_run:
+            assert (github_stack := github_stack_plan.affected_stack) is not None
             await GithubStackSelection(
                 github_client,
-                native_stack.pull_request_numbers,
-            ).dissolve_exact(observed=(native_stack,))
-            native_plan = NativeStackPlan("create" if len(pending_syncs) > 1 else "none")
+                github_stack.pull_request_numbers,
+            ).dissolve_exact(observed=(github_stack,))
+            github_stack_plan = GithubStackPlan("create" if len(pending_syncs) > 1 else "none")
         if not dry_run:
+            await require_current_github_stack_plan(
+                github_client=github_client,
+                plan=github_stack_plan,
+                pull_numbers=desired_pull_numbers,
+            )
             if pushes_review_branches:
                 await retarget_review_bases_before_branch_push(
                     github_client=github_client,
@@ -592,10 +602,12 @@ async def run_submit_async(
                 if (pull_number := revision.pull_request_number) is not None
             )
             if len(pull_numbers) != len(submitted_revisions):
-                raise AssertionError("Native submit requires concrete pull request numbers.")
-            await apply_native_stack_plan(
+                raise AssertionError(
+                    "GitHub stack submit requires concrete pull request numbers."
+                )
+            await apply_github_stack_plan(
                 github_client=github_client,
-                plan=native_plan,
+                plan=github_stack_plan,
                 pull_numbers=pull_numbers,
             )
             await sync_stack_overview_comments(

--- a/src/jj_stack/commands/submit/github_stack.py
+++ b/src/jj_stack/commands/submit/github_stack.py
@@ -1,20 +1,25 @@
-"""Plan and apply native GitHub stack membership for submit."""
+"""Plan and apply GitHub stack membership for submit."""
 
 from collections.abc import Sequence, Set
 from dataclasses import dataclass
 from typing import Literal
 
 import jj_stack.ui as ui
-from jj_stack.commands._native_stack_safety import selected_native_stack
+from jj_stack.commands._github_stack_safety import selected_github_stack
 from jj_stack.errors import CliError
 from jj_stack.github.client import GithubClient, GithubClientError
 from jj_stack.models.github import GithubStack
 
 
 @dataclass(frozen=True, slots=True)
-class NativeStackPlan:
+class GithubStackPlan:
     action: Literal["none", "create", "append", "replace"]
     affected_stack: GithubStack | None = None
+
+    def __post_init__(self) -> None:
+        has_stack = self.affected_stack is not None
+        if has_stack != (self.action in ("append", "replace")):
+            raise ValueError(f"Invalid GitHub stack plan: {self.action} with stack={has_stack}")
 
     @property
     def membership_key(self) -> tuple[str, tuple[int, tuple[int, ...]] | None]:
@@ -22,78 +27,99 @@ class NativeStackPlan:
         return self.action, None if stack is None else (stack.number, stack.pull_request_numbers)
 
 
-def plan_native_stack(
+def plan_github_stack(
     *,
     desired: tuple[int | None, ...],
     observed_stacks: Sequence[GithubStack],
     pull_numbers_requiring_base_update: Set[int],
-) -> NativeStackPlan:
+) -> GithubStackPlan:
     known_desired = tuple(number for number in desired if number is not None)
     if len(set(known_desired)) != len(known_desired):
         raise CliError("Selected changes resolve to the same pull request more than once.")
 
     selected = set(known_desired)
-    stack = selected_native_stack(selected_pull_numbers=selected, stacks=observed_stacks)
+    stack = selected_github_stack(selected_pull_numbers=selected, stacks=observed_stacks)
     if stack is None or selected.isdisjoint(stack.active_pull_request_numbers):
-        return NativeStackPlan("none" if len(desired) < 2 else "create")
+        return GithubStackPlan("none" if len(desired) < 2 else "create")
     active_pull_numbers = stack.active_pull_request_numbers
 
     if set(active_pull_numbers).intersection(pull_numbers_requiring_base_update):
-        return NativeStackPlan("replace", stack)
+        return GithubStackPlan("replace", stack)
 
     if active_pull_numbers == desired:
-        return NativeStackPlan("none")
+        return GithubStackPlan("none")
     if (
         len(active_pull_numbers) < len(desired)
         and active_pull_numbers == desired[: len(active_pull_numbers)]
     ):
-        return NativeStackPlan("append", stack)
-    return NativeStackPlan("replace", stack)
+        return GithubStackPlan("append", stack)
+    return GithubStackPlan("replace", stack)
 
 
 def _membership_error(message: str) -> CliError:
     return CliError(message, hint=t"Rerun {ui.cmd('jj-stack submit')} to inspect membership.")
 
 
-async def apply_native_stack_plan(
+async def apply_github_stack_plan(
     *,
     github_client: GithubClient,
-    plan: NativeStackPlan,
+    plan: GithubStackPlan,
     pull_numbers: tuple[int, ...],
 ) -> None:
     if plan.action == "none":
         return
     assert plan.action != "replace"
     try:
-        current_plan = plan_native_stack(
-            desired=pull_numbers,
-            observed_stacks=await github_client.list_stacks(),
-            pull_numbers_requiring_base_update=frozenset(),
+        current_plan = await require_current_github_stack_plan(
+            github_client=github_client,
+            plan=plan,
+            pull_numbers=pull_numbers,
         )
-        if current_plan.membership_key != plan.membership_key:
-            raise _membership_error("Native GitHub stack membership changed during submit.")
-        stack = current_plan.affected_stack
-        if stack is None:
+        if current_plan.action == "create":
             updated = await github_client.create_stack(pull_numbers=pull_numbers)
             expected_number = updated.number
-        else:
+            expected_members = pull_numbers
+        elif current_plan.action == "append":
+            assert (stack := current_plan.affected_stack) is not None
             updated = await github_client.append_to_stack(
                 stack_number=stack.number,
                 pull_numbers=pull_numbers[len(stack.active_pull_request_numbers) :],
             )
             expected_number = stack.number
-        expected_members = (
-            pull_numbers
-            if stack is None
-            else (*stack.historical_pull_request_numbers, *pull_numbers)
-        )
+            expected_members = (*stack.historical_pull_request_numbers, *pull_numbers)
+        else:
+            raise AssertionError(f"Cannot apply GitHub stack plan {current_plan.action!r}.")
         if (updated.number, updated.pull_request_numbers) != (
             expected_number,
             expected_members,
         ):
-            raise _membership_error("GitHub returned unexpected native stack membership.")
+            raise _membership_error("GitHub returned unexpected stack membership.")
     except GithubClientError as error:
         raise CliError(
-            "Could not update the native GitHub stack",
+            "Could not update the GitHub stack",
             hint=t"Resolve GitHub's reported error, then rerun {ui.cmd('jj-stack submit')}.",
         ) from error
+
+
+async def require_current_github_stack_plan(
+    *,
+    github_client: GithubClient,
+    plan: GithubStackPlan,
+    pull_numbers: tuple[int | None, ...],
+) -> GithubStackPlan:
+    """Recheck exact stack membership before a dependent submit mutation."""
+
+    try:
+        current_plan = plan_github_stack(
+            desired=pull_numbers,
+            observed_stacks=await github_client.list_stacks(),
+            pull_numbers_requiring_base_update=frozenset(),
+        )
+    except GithubClientError as error:
+        raise CliError(
+            "Could not inspect GitHub stack membership.",
+            hint=t"Resolve GitHub's reported error, then rerun {ui.cmd('jj-stack submit')}.",
+        ) from error
+    if current_plan.membership_key != plan.membership_key:
+        raise _membership_error("GitHub stack membership changed during submit.")
+    return current_plan

--- a/src/jj_stack/commands/submit/render.py
+++ b/src/jj_stack/commands/submit/render.py
@@ -20,7 +20,7 @@ def print_submit_result(result: SubmitResult) -> None:
     client = result.client
     prerendered_blocks: dict[str, tuple[str, ...]] = {}
     if client is not None:
-        # Overlap the native `jj log` subprocess startup cost before we print
+        # Overlap the `jj log` subprocess startup cost before we print
         # the final summary for large stacks.
         with console.spinner(description="Rendering jj log"):
             prerendered_blocks = render_revision_blocks(

--- a/src/jj_stack/commands/sync.py
+++ b/src/jj_stack/commands/sync.py
@@ -50,7 +50,7 @@ from jj_stack.review.finish import (
     render_finish_results,
     retire_reviews,
 )
-from jj_stack.review.native_sync import resolve_selected_native_observation
+from jj_stack.review.github_stack_sync import resolve_selected_github_stack_observation
 from jj_stack.review.observation import (
     RepositoryObservation,
     observe_reviews,
@@ -146,9 +146,8 @@ async def _run_selected_convergence(
             remote_name=target.remote.name,
             trunk_branch=trunk_branch,
         )
-        observation, native_stacks = await resolve_selected_native_observation(
+        observation, github_stacks = await resolve_selected_github_stack_observation(
             context=context,
-            dry_run=dry_run,
             github=github,
             initial=observation,
             remote_name=target.remote.name,
@@ -171,7 +170,7 @@ async def _run_selected_convergence(
             )
         plan = build_selected_convergence_plan(
             context=context,
-            native_stacks=native_stacks,
+            github_stacks=github_stacks,
             observation=observation,
             prepared_status=prepared_status,
             repository=target.repository,
@@ -232,7 +231,7 @@ async def _apply_selected_plan(
         skip_finish=frozenset(
             change.candidate.change_id
             for change in plan.on_trunk
-            if change.evidence_kind != "exact" or change.native
+            if change.evidence_kind != "exact" or change.requires_terminal_pull_request
         ),
     )
     rebase_revision_ids = (
@@ -247,13 +246,17 @@ async def _apply_selected_plan(
         )
 
     if not dry_run:
-        native = plan.native_survivors
-        if native:
-            top = native[-1]
-            rebase_revision_ids = rebase_revision_ids[len(native) :]
+        github_stack_survivors = plan.github_stack_survivors
+        if github_stack_survivors:
+            top = github_stack_survivors[-1]
+            rebase_revision_ids = rebase_revision_ids[len(github_stack_survivors) :]
             replaced = tuple(
                 revision.commit_id
-                for revision, survivor in zip(plan.survivors[: len(native)], native, strict=False)
+                for revision, survivor in zip(
+                    plan.survivors[: len(github_stack_survivors)],
+                    github_stack_survivors,
+                    strict=False,
+                )
                 if revision.commit_id != survivor.remote_head_commit_id
             )
             destination = top.remote_head_commit_id
@@ -268,7 +271,7 @@ async def _apply_selected_plan(
                         survivor.remote_head_commit_id,
                         survivor.candidate.change_id,
                     )
-                    for survivor in native
+                    for survivor in github_stack_survivors
                 ),
                 expected_parent_commit_id=trunk_commit_id,
             )
@@ -324,21 +327,21 @@ async def _apply_selected_plan(
             )
             if abandoned:
                 context.jj_client.abandon_revisions(abandoned)
-            if native:
+            if github_stack_survivors:
                 context.state_store.relink_reviews(
                     expected={
                         survivor.candidate.change_id: (
                             survivor.candidate.review_identity,
                             survivor.candidate.submitted_baseline,
                         )
-                        for survivor in native
+                        for survivor in github_stack_survivors
                     },
                     replacements={
                         survivor.candidate.change_id: (
                             survivor.candidate.review_identity,
                             SubmittedBaseline(commit_id=survivor.remote_head_commit_id),
                         )
-                        for survivor in native
+                        for survivor in github_stack_survivors
                     },
                 )
     update_result = await _update_selected_reviews(
@@ -352,7 +355,9 @@ async def _apply_selected_plan(
         finish=finish_context,
         retirement_blocker=retirement_blocker,
         terminal_required=frozenset(
-            change.candidate.change_id for change in plan.on_trunk if change.native
+            change.candidate.change_id
+            for change in plan.on_trunk
+            if change.requires_terminal_pull_request
         ),
     )
     render_finish_results(dry_run=dry_run, results=results)

--- a/src/jj_stack/commands/sync_global.py
+++ b/src/jj_stack/commands/sync_global.py
@@ -17,7 +17,7 @@ from jj_stack.review.finish import (
     render_finish_results,
     retire_reviews,
 )
-from jj_stack.review.native_sync import observe_native_stacks
+from jj_stack.review.github_stack_sync import observe_github_stacks
 from jj_stack.review.observation import duplicate_review_claim_change_ids
 from jj_stack.review.trunk_evidence import (
     CommitAncestry,
@@ -80,7 +80,7 @@ async def run_global_recovery(*, context: CommandContext, dry_run: bool) -> int:
                 candidate.review_identity.pr_number for candidate in all_candidates
             )
         )
-        native_stacks = await observe_native_stacks(github=github) if exact_candidates else ()
+        github_stacks = await observe_github_stacks(github=github) if exact_candidates else ()
         merge_ancestry = classify_commit_ancestries(
             commit_ids=tuple(
                 pull_request.merge_commit_sha
@@ -110,7 +110,7 @@ async def run_global_recovery(*, context: CommandContext, dry_run: bool) -> int:
             )
         eligible_exact, terminal_required = _eligible_exact_candidates(
             candidates=exact_candidates,
-            native_stacks=native_stacks,
+            github_stacks=github_stacks,
             pull_requests=pull_requests,
             tracked_pull_numbers=frozenset(
                 identity.pr_number
@@ -145,11 +145,11 @@ async def run_global_recovery(*, context: CommandContext, dry_run: bool) -> int:
 
 def _eligible_exact_candidates(
     candidates: tuple[TrackedReview, ...],
-    native_stacks: tuple[GithubStack, ...],
+    github_stacks: tuple[GithubStack, ...],
     pull_requests: dict[int, GithubPullRequest | GithubClientError | None],
     tracked_pull_numbers: frozenset[int],
 ) -> tuple[tuple[TrackedReview, ...], frozenset[str]]:
-    members = [member for stack in native_stacks for member in stack.pull_requests]
+    members = [member for stack in github_stacks for member in stack.pull_requests]
     eligible: list[TrackedReview] = []
     terminal_required: set[str] = set()
     for candidate in candidates:
@@ -160,7 +160,7 @@ def _eligible_exact_candidates(
             continue
         reason = _github_stack_blocker(
             matching=matching,
-            native_stacks=native_stacks,
+            github_stacks=github_stacks,
             number=number,
             pull_request=pull_requests.get(number),
             tracked_pull_numbers=tracked_pull_numbers,
@@ -176,7 +176,7 @@ def _eligible_exact_candidates(
 def _github_stack_blocker(
     *,
     matching: list[GithubStackPullRequest],
-    native_stacks: tuple[GithubStack, ...],
+    github_stacks: tuple[GithubStack, ...],
     number: int,
     pull_request: object,
     tracked_pull_numbers: frozenset[int],
@@ -196,7 +196,7 @@ def _github_stack_blocker(
     if any(
         number in stack.pull_request_numbers
         and not set(stack.active_pull_request_numbers).isdisjoint(tracked_pull_numbers)
-        for stack in native_stacks
+        for stack in github_stacks
     ):
         return t"PR #{number} is in a GitHub stack that still has active members tracked here"
     return None

--- a/src/jj_stack/commands/unstack.py
+++ b/src/jj_stack/commands/unstack.py
@@ -42,7 +42,7 @@ from jj_stack.commands._close_actions import (
     prepare_current_review_cleanup,
 )
 from jj_stack.commands._fetch_isolation import report_fetch_isolation
-from jj_stack.commands._native_stack_safety import GithubStackSelection
+from jj_stack.commands._github_stack_safety import GithubStackSelection
 from jj_stack.commands.close_orphan import (
     run_orphan_close,
     run_untracked_cleanup_pull_request,
@@ -690,10 +690,10 @@ async def _stream_close_async(
                 if prepared_revision.revision.change_id in review_identities
             ),
         )
-        native_stacks = await selection.active_stacks()
+        github_stacks = await selection.active_stacks()
         initial_observation = None
         blocked = False
-        if native_stacks or prepared_close.cleanup:
+        if github_stacks or prepared_close.cleanup:
             if prepared.remote is None:
                 raise AssertionError("Tracked unstack requires a configured remote.")
             try:
@@ -716,8 +716,8 @@ async def _stream_close_async(
             prepared_close=prepared_close,
             record_action=recorder.record,
         )
-        if native_stacks and not blocked:
-            native_preflight = (
+        if github_stacks and not blocked:
+            stack_preflight = (
                 _close_revision_preflight_error(
                     change_status=classify_review_status_revision(revision),
                     revision=revision,
@@ -726,7 +726,7 @@ async def _stream_close_async(
                 for revision in status_result.revisions
             )
             blocker = next(
-                (action for action in native_preflight if action is not None),
+                (action for action in stack_preflight if action is not None),
                 None,
             )
             if blocker is None:
@@ -740,16 +740,16 @@ async def _stream_close_async(
                 recorder.record(blocker)
                 blocked = True
             else:
-                native_stack = (
-                    await selection.recheck_active_suffix(observed=native_stacks)
+                github_stack = (
+                    await selection.recheck_active_suffix(observed=github_stacks)
                     if prepared_close.dry_run
-                    else await selection.dissolve_exact(observed=native_stacks)
+                    else await selection.dissolve_exact(observed=github_stacks)
                 )
-                if native_stack is not None:
+                if github_stack is not None:
                     recorder.record(
                         CloseAction(
                             kind="GitHub stack",
-                            body=t"dissolve GitHub stack #{native_stack.number}",
+                            body=t"dissolve GitHub stack #{github_stack.number}",
                             status="planned" if prepared_close.dry_run else "applied",
                         )
                     )

--- a/src/jj_stack/commands/view.py
+++ b/src/jj_stack/commands/view.py
@@ -27,8 +27,8 @@ from jj_stack.commands._json_status import review_change_json
 from jj_stack.commands._stale_stacks import emit_stale_stacks_advisory
 from jj_stack.errors import EXIT_INCOMPLETE, CliError, error_message
 from jj_stack.formatting import (
-    NativeRevision,
-    NativeRevisionRenderClient,
+    RenderableRevision,
+    RevisionRenderClient,
     format_pull_request_label,
     render_revision_blocks,
     render_revision_lines,
@@ -573,7 +573,7 @@ def render_trunk_status_lines(
     prepared: PreparedStack,
     prerendered_blocks: dict[str, tuple[str, ...]] | None = None,
 ) -> tuple[str, ...]:
-    """Render the trunk footer with native `jj log` formatting."""
+    """Render the trunk footer with the user's `jj log` formatting."""
 
     trunk = prepared.stack.base_parent
     return render_revision_lines(
@@ -601,14 +601,14 @@ def render_empty_status_lines(
 
 def _prefetch_revision_log_blocks(
     *,
-    client: NativeRevisionRenderClient,
+    client: RevisionRenderClient,
     revisions: tuple[ReviewStatusRevision, ...],
-    trunk: NativeRevision,
+    trunk: RenderableRevision,
 ) -> dict[str, tuple[str, ...]]:
     """Render the `jj log` block for every revision we will print, in parallel."""
 
     seen: set[str] = set()
-    ordered: list[NativeRevision] = []
+    ordered: list[RenderableRevision] = []
     for revision in (*revisions, trunk):
         if revision.commit_id in seen:
             continue

--- a/src/jj_stack/formatting.py
+++ b/src/jj_stack/formatting.py
@@ -8,15 +8,15 @@ from typing import IO, Literal, Protocol
 from jj_stack.console import RequestedColorMode, requested_color_mode
 
 
-class NativeRevision(Protocol):
+class RenderableRevision(Protocol):
     """Revision-like value that can be rendered by commit ID."""
 
     @property
     def commit_id(self) -> str: ...
 
 
-class NativeRevisionRenderClient(Protocol):
-    """Subset of the jj client interface used for native revision rendering."""
+class RevisionRenderClient(Protocol):
+    """Subset of the jj client interface used for revision rendering."""
 
     def resolve_color_when(
         self,
@@ -27,14 +27,14 @@ class NativeRevisionRenderClient(Protocol):
 
     def render_revision_log_lines(
         self,
-        revision: NativeRevision,
+        revision: RenderableRevision,
         *,
         color_when: Literal["always", "debug", "never"],
     ) -> tuple[str, ...]: ...
 
     def render_revision_log_blocks(
         self,
-        revisions: tuple[NativeRevision, ...],
+        revisions: tuple[RenderableRevision, ...],
         *,
         color_when: Literal["always", "debug", "never"],
     ) -> dict[str, tuple[str, ...]]: ...
@@ -62,8 +62,8 @@ def format_pull_request_label(
 
 def render_revision_lines(
     *,
-    client: NativeRevisionRenderClient,
-    revision: NativeRevision,
+    client: RevisionRenderClient,
+    revision: RenderableRevision,
     stdout: IO[str] | None = None,
     suffix: str | None = None,
     prerendered_lines: tuple[str, ...] | None = None,
@@ -89,8 +89,8 @@ def render_revision_lines(
 
 def render_revision_blocks(
     *,
-    client: NativeRevisionRenderClient,
-    revisions: tuple[NativeRevision, ...],
+    client: RevisionRenderClient,
+    revisions: tuple[RenderableRevision, ...],
     stdout: IO[str] | None = None,
 ) -> dict[str, tuple[str, ...]]:
     """Render several revisions using the active CLI/UI color policy."""

--- a/src/jj_stack/github/client.py
+++ b/src/jj_stack/github/client.py
@@ -18,13 +18,13 @@ from jj_stack.errors import EXIT_GITHUB, SummarizedError
 from jj_stack.github.auth import github_token, github_token_from_env
 from jj_stack.github.resolution import GithubRepoAddress
 from jj_stack.models.github import (
-    GithubAsyncMerge,
-    GithubAsyncMergeSubmission,
     GithubIssueComment,
     GithubPullRequest,
     GithubPullRequestReview,
     GithubRepository,
     GithubStack,
+    GithubStackMerge,
+    GithubStackMergeSubmission,
 )
 
 logger = logging.getLogger(__name__)
@@ -565,7 +565,7 @@ class GithubClient:
         expected_head_sha: str,
         merge_method: str,
         pull_number: int,
-    ) -> GithubAsyncMergeSubmission:
+    ) -> GithubStackMergeSubmission:
         response = await self._request(
             "PUT",
             f"{self._repo_path}/pulls/{pull_number}/merge-async",
@@ -584,9 +584,9 @@ class GithubClient:
                 ) from error
         else:
             payload = self._expect_success(response)
-        return GithubAsyncMergeSubmission(
+        return GithubStackMergeSubmission(
             already_pending=already_pending,
-            result=_validate_async_merge_payload(payload),
+            result=_validate_stack_merge_payload(payload),
         )
 
     async def poll_stack_merge(
@@ -594,12 +594,12 @@ class GithubClient:
         *,
         operation_uuid: str,
         pull_number: int,
-    ) -> GithubAsyncMerge:
+    ) -> GithubStackMerge:
         response = await self._request(
             "GET",
             f"{self._repo_path}/pulls/{pull_number}/merge-async/{operation_uuid}",
         )
-        return _validate_async_merge_payload(self._expect_success(response))
+        return _validate_stack_merge_payload(self._expect_success(response))
 
     async def close_pull_request(
         self,
@@ -1070,11 +1070,11 @@ def _validate_stack_payload(payload: object, *, response_name: str) -> GithubSta
         ) from error
 
 
-def _validate_async_merge_payload(payload: object) -> GithubAsyncMerge:
+def _validate_stack_merge_payload(payload: object) -> GithubStackMerge:
     try:
-        return GithubAsyncMerge.model_validate(payload)
+        return GithubStackMerge.model_validate(payload)
     except ValidationError as error:
-        raise GithubClientError("GitHub async merge response had invalid data.") from error
+        raise GithubClientError("GitHub stack merge response had invalid data.") from error
 
 
 def _validate_graphql_model[GraphqlModel: BaseModel](

--- a/src/jj_stack/jj/client.py
+++ b/src/jj_stack/jj/client.py
@@ -152,7 +152,7 @@ class StaleWorkspaceError(CliError):
     """Raised when `jj` refuses to run because the current workspace is stale."""
 
 
-class _NativeRevision(Protocol):
+class _RenderableRevision(Protocol):
     @property
     def commit_id(self) -> str: ...
 
@@ -421,11 +421,11 @@ class JjClient:
 
     def render_revision_log_lines(
         self,
-        revision: _NativeRevision,
+        revision: _RenderableRevision,
         *,
         color_when: JjColorWhen,
     ) -> tuple[str, ...]:
-        """Render one revision with the user's native `jj log` formatting."""
+        """Render one revision with the user's `jj log` formatting."""
 
         stdout = self._run_jj(
             (
@@ -444,7 +444,7 @@ class JjClient:
 
     def render_revision_log_blocks(
         self,
-        revisions: Sequence[_NativeRevision],
+        revisions: Sequence[_RenderableRevision],
         *,
         color_when: JjColorWhen,
     ) -> dict[str, tuple[str, ...]]:

--- a/src/jj_stack/models/github.py
+++ b/src/jj_stack/models/github.py
@@ -34,7 +34,7 @@ class GithubBranchRef(BaseModel):
 
 
 class GithubStackPullRequestHead(BaseModel):
-    """Exact reviewed branch head embedded in a native stack response."""
+    """Exact reviewed branch head embedded in a GitHub stack response."""
 
     model_config = ConfigDict(extra="ignore")
 
@@ -43,7 +43,7 @@ class GithubStackPullRequestHead(BaseModel):
 
 
 class GithubStackPullRequest(BaseModel):
-    """Pull request state embedded in a native stack response."""
+    """Pull request state embedded in a GitHub stack response."""
 
     model_config = ConfigDict(extra="ignore")
 
@@ -57,7 +57,7 @@ class GithubStackPullRequest(BaseModel):
 
 
 class GithubStack(BaseModel):
-    """Ordered pull requests in one native GitHub stack."""
+    """Ordered pull requests in one GitHub stack."""
 
     model_config = ConfigDict(extra="ignore")
 
@@ -95,12 +95,12 @@ class GithubStack(BaseModel):
             if not pull_request.is_historical:
                 active_seen = True
             elif active_seen:
-                raise ValueError("Merged native stack members must form a bottom prefix.")
+                raise ValueError("Merged GitHub stack members must form a bottom prefix.")
         return self
 
 
-class GithubAsyncMergeDetails(BaseModel):
-    """Details returned by GitHub's native asynchronous merge endpoint."""
+class GithubStackMergeDetails(BaseModel):
+    """Details returned by GitHub's asynchronous stack merge endpoint."""
 
     model_config = ConfigDict(extra="ignore")
 
@@ -111,16 +111,16 @@ class GithubAsyncMergeDetails(BaseModel):
     uuid: str | None = None
 
 
-class GithubAsyncMerge(BaseModel):
-    """Pending or terminal native asynchronous merge state."""
+class GithubStackMerge(BaseModel):
+    """Pending or terminal asynchronous stack merge state."""
 
     model_config = ConfigDict(extra="ignore")
 
-    details: GithubAsyncMergeDetails
+    details: GithubStackMergeDetails
     status: Literal["failed", "merged", "pending"]
 
 
-class GithubAsyncMergeSubmission(BaseModel):
+class GithubStackMergeSubmission(BaseModel):
     """Typed submit response for an asynchronous merge request.
 
     `already_pending` reports GitHub's 409, which means an operation for this pull request is
@@ -129,7 +129,7 @@ class GithubAsyncMergeSubmission(BaseModel):
     """
 
     already_pending: bool
-    result: GithubAsyncMerge
+    result: GithubStackMerge
 
 
 class GithubPullRequest(BaseModel):

--- a/src/jj_stack/review/convergence.py
+++ b/src/jj_stack/review/convergence.py
@@ -8,9 +8,9 @@ from jj_stack.errors import CliError
 from jj_stack.github.resolution import GithubRepoAddress
 from jj_stack.models.github import GithubStack
 from jj_stack.models.stack import LocalRevision
-from jj_stack.review.native_sync import (
-    NativeSurvivorReview,
-    build_selected_native_sync,
+from jj_stack.review.github_stack_sync import (
+    GithubStackSurvivorReview,
+    build_selected_github_stack_sync,
 )
 from jj_stack.review.observation import RepositoryObservation
 from jj_stack.review.repository import observe_repository_paths
@@ -27,14 +27,14 @@ from jj_stack.ui import Message
 class OnTrunkChange:
     candidate: TrackedReview
     evidence_kind: TrunkEvidenceKind
-    native: bool
+    requires_terminal_pull_request: bool
     revision: LocalRevision | None
 
 
 @dataclass(frozen=True, slots=True)
 class SelectedConvergencePlan:
     on_trunk: tuple[OnTrunkChange, ...]
-    native_survivors: tuple[NativeSurvivorReview, ...]
+    github_stack_survivors: tuple[GithubStackSurvivorReview, ...]
     reviewed_survivors: tuple[LocalRevision, ...]
     survivors: tuple[LocalRevision, ...]
 
@@ -42,7 +42,7 @@ class SelectedConvergencePlan:
 def build_selected_convergence_plan(
     *,
     context: CommandContext,
-    native_stacks: tuple[GithubStack, ...],
+    github_stacks: tuple[GithubStack, ...],
     observation: RepositoryObservation,
     prepared_status: PreparedStatus,
     repository: GithubRepoAddress,
@@ -63,35 +63,35 @@ def build_selected_convergence_plan(
             hint=t"Run {ui.cmd('jj-stack list')} to find them, then drop the wrong one with "
             t"{ui.cmd('jj-stack unstack --local')}.",
         )
-    native_history, native_active = build_selected_native_sync(
+    stack_history, stack_survivor_reviews = build_selected_github_stack_sync(
         context=context,
-        native_stacks=native_stacks,
+        github_stacks=github_stacks,
         observation=observation,
         repository=repository,
         selected=selected,
         state=state,
         trunk_commit_id=prepared_status.prepared.stack.trunk.commit_id,
     )
-    native_historical = {item.candidate.change_id: item for item in native_history}
-    native_survivors = {item.candidate.change_id: item for item in native_active}
+    stack_history_by_change_id = {item.candidate.change_id: item for item in stack_history}
+    github_stack_survivors = {item.candidate.change_id: item for item in stack_survivor_reviews}
     on_trunk: list[OnTrunkChange] = [
         OnTrunkChange(
             candidate=item.candidate,
             evidence_kind=item.evidence_kind,
-            native=True,
+            requires_terminal_pull_request=True,
             revision=item.revision,
         )
-        for item in native_historical.values()
+        for item in stack_history_by_change_id.values()
     ]
     survivors: list[LocalRevision] = []
     for revision in filter(
-        lambda item: item.change_id not in native_historical,
+        lambda item: item.change_id not in stack_history_by_change_id,
         selected,
     ):
         candidate = state.tracked_review(revision.change_id)
         evidence_kind = (
             None
-            if candidate is None or revision.change_id in native_survivors
+            if candidate is None or revision.change_id in github_stack_survivors
             else _trunk_evidence_kind_for(
                 candidate=candidate,
                 context=context,
@@ -128,7 +128,7 @@ def build_selected_convergence_plan(
             OnTrunkChange(
                 candidate=candidate,
                 evidence_kind=evidence_kind,
-                native=False,
+                requires_terminal_pull_request=False,
                 revision=revision,
             )
         )
@@ -171,7 +171,7 @@ def build_selected_convergence_plan(
         reviewed.append(revision)
     plan = SelectedConvergencePlan(
         on_trunk=tuple(on_trunk),
-        native_survivors=tuple(native_survivors.values()),
+        github_stack_survivors=tuple(github_stack_survivors.values()),
         reviewed_survivors=tuple(reviewed),
         survivors=tuple(survivors),
     )

--- a/src/jj_stack/review/github_stack_sync.py
+++ b/src/jj_stack/review/github_stack_sync.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 import jj_stack.review.observation as review_observation
 import jj_stack.ui as ui
 from jj_stack.bootstrap import CommandContext
-from jj_stack.commands._native_stack_safety import selected_native_stack
+from jj_stack.commands._github_stack_safety import selected_github_stack
 from jj_stack.errors import CliError
 from jj_stack.github.client import GithubClient, GithubClientError
 from jj_stack.github.resolution import GithubRepoAddress
@@ -20,37 +20,36 @@ from jj_stack.review.trunk_evidence import (
 
 
 @dataclass(frozen=True, slots=True)
-class NativeHistoricalReview:
+class GithubStackHistoryReview:
     candidate: TrackedReview
     evidence_kind: TrunkEvidenceKind
     revision: LocalRevision | None
 
 
 @dataclass(frozen=True, slots=True)
-class NativeSurvivorReview:
+class GithubStackSurvivorReview:
     candidate: TrackedReview
     remote_head_commit_id: str
 
 
-async def observe_native_stacks(
+async def observe_github_stacks(
     *,
     github: GithubClient,
 ) -> tuple[GithubStack, ...]:
-    """Read the current native resources."""
+    """Read the current GitHub stack resources."""
 
     try:
         return await github.list_stacks()
     except GithubClientError as error:
         raise CliError(
-            "Could not inspect native GitHub stack membership.",
+            "Could not inspect GitHub stack membership.",
             hint=t"Resolve the GitHub error above, then rerun the command.",
         ) from error
 
 
-async def resolve_selected_native_observation(
+async def resolve_selected_github_stack_observation(
     *,
     context: CommandContext,
-    dry_run: bool,
     github: GithubClient,
     initial: review_observation.RepositoryObservation,
     remote_name: str,
@@ -70,7 +69,7 @@ async def resolve_selected_native_observation(
         _changed_review(initial.reviews[revision.change_id]) for revision in selected
     ):
         return initial, ()
-    stacks = await observe_native_stacks(github=github)
+    stacks = await observe_github_stacks(github=github)
 
     selected_pull_numbers = {
         identity.pr_number
@@ -115,16 +114,16 @@ def _changed_review(observed: review_observation.ReviewObservation) -> bool:
     )
 
 
-def build_selected_native_sync(
+def build_selected_github_stack_sync(
     *,
     context: CommandContext,
-    native_stacks: tuple[GithubStack, ...],
+    github_stacks: tuple[GithubStack, ...],
     observation: review_observation.RepositoryObservation,
     repository: GithubRepoAddress,
     selected: tuple[LocalRevision, ...],
     state: ReviewState,
     trunk_commit_id: str,
-) -> tuple[tuple[NativeHistoricalReview, ...], tuple[NativeSurvivorReview, ...]]:
+) -> tuple[tuple[GithubStackHistoryReview, ...], tuple[GithubStackSurvivorReview, ...]]:
     selected_by_change_id = {revision.change_id: revision for revision in selected}
     candidates_by_pull = {
         candidate.review_identity.pr_number: candidate
@@ -140,9 +139,9 @@ def build_selected_native_sync(
     selected_pull_numbers = {
         candidate.review_identity.pr_number for candidate in selected_candidates
     }
-    stack = selected_native_stack(
+    stack = selected_github_stack(
         selected_pull_numbers=selected_pull_numbers,
-        stacks=native_stacks,
+        stacks=github_stacks,
     )
     if stack is None:
         return (), ()
@@ -160,8 +159,8 @@ def build_selected_native_sync(
             hint=t"Bring them back into line with {ui.cmd('jj-stack submit')}, or dissolve the "
             t"stack with {ui.cmd(f'gh stack unstack {stack.number}')} and resubmit.",
         )
-    historical: list[NativeHistoricalReview] = []
-    survivors: list[NativeSurvivorReview] = []
+    historical: list[GithubStackHistoryReview] = []
+    survivors: list[GithubStackSurvivorReview] = []
     _require_history(stack, set(candidates_by_pull))
     for member in stack.pull_requests:
         candidate = candidates_by_pull.get(member.number)
@@ -210,11 +209,11 @@ def build_selected_native_sync(
             or observed.remote_review_target != member.head.sha
         ):
             raise CliError(
-                t"Active native member PR #{member.number} does not match its reviewed branch.",
+                t"Active stack member PR #{member.number} does not match its reviewed branch.",
                 hint=t"Republish the review with {ui.cmd('jj-stack submit')}, then rerun sync.",
             )
         survivors.append(
-            NativeSurvivorReview(
+            GithubStackSurvivorReview(
                 candidate=candidate,
                 remote_head_commit_id=member.head.sha,
             )
@@ -243,7 +242,7 @@ def _historical_review(
     repository: GithubRepoAddress,
     revision: LocalRevision | None,
     trunk_commit_id: str,
-) -> NativeHistoricalReview:
+) -> GithubStackHistoryReview:
     evidence_kind, reason = proven_kind(
         candidate=candidate,
         context=context,
@@ -253,10 +252,10 @@ def _historical_review(
     )
     if evidence_kind is None:
         raise CliError(
-            t"Cannot retire native member PR #{member.number}: {reason}.",
+            t"Cannot retire stack member PR #{member.number}: {reason}.",
             hint=t"Make GitHub's merge result reachable from trunk, then rerun sync.",
         )
-    return NativeHistoricalReview(
+    return GithubStackHistoryReview(
         candidate=candidate,
         evidence_kind=evidence_kind,
         revision=revision,
@@ -281,7 +280,7 @@ def _validated_member_pull_request(
         or pull_request.head.ref != member.head.ref
     ):
         raise CliError(
-            t"Native member PR #{member.number} no longer matches its saved review identity.",
+            t"Stack member PR #{member.number} no longer matches its saved review identity.",
             hint=t"Reattach it with {ui.cmd('jj-stack relink')}, or end the review with "
             t"{ui.cmd('jj-stack unstack --cleanup')} and submit it again.",
         )

--- a/src/jj_stack/review/path.py
+++ b/src/jj_stack/review/path.py
@@ -195,7 +195,7 @@ def _select_revision(observation: SelectedPathObservation) -> LocalRevision:
         if len(off_trunk) > 1:
             raise AmbiguousSelectionError("The selector resolved to more than one revision.")
         if off_trunk:
-            # A native merge side parent is immutable to jj but remains outside
+            # A stack merge side parent is immutable to jj but remains outside
             # the fetched trunk's first-parent path until selected sync retires it.
             return off_trunk[0]
         raise CliError("The selected change has no mutable local copy.")

--- a/tests/integration/test_cleanup_command.py
+++ b/tests/integration/test_cleanup_command.py
@@ -46,7 +46,7 @@ def test_cleanup_retires_closed_review_after_local_change_is_abandoned(
     )
 
 
-def test_cleanup_blocks_closed_review_still_claimed_by_native_stack(
+def test_cleanup_blocks_closed_review_still_claimed_by_github_stack(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -64,7 +64,7 @@ def test_cleanup_blocks_closed_review_still_claimed_by_native_stack(
     for pull_request in fake_repo.pull_requests.values():
         pull_request.state = "closed"
     run_command(["jj", "abandon", *change_ids], repo)
-    fake_repo.native_stacks = {7: (1, 2)}
+    fake_repo.github_stacks = {7: (1, 2)}
     state_before = state_store.load()
 
     preview_exit_code = run_main(repo, config_path, "cleanup", "--dry-run")
@@ -93,7 +93,7 @@ def test_cleanup_blocks_closed_review_still_claimed_by_native_stack(
         f"refs/heads/{bookmark}" in remote_refs(fake_repo.git_dir) for bookmark in bookmarks
     )
 
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
     apply_exit_code = run_main(repo, config_path, "cleanup")
     applied = capsys.readouterr()
     normalized_applied = " ".join(applied.out.split())
@@ -107,7 +107,7 @@ def test_cleanup_blocks_closed_review_still_claimed_by_native_stack(
     assert all(
         f"refs/heads/{bookmark}" not in remote_refs(fake_repo.git_dir) for bookmark in bookmarks
     )
-    assert fake_repo.native_stacks == {}
+    assert fake_repo.github_stacks == {}
 
 
 def test_cleanup_preserves_closed_review_branch_used_by_open_pull_request(
@@ -230,7 +230,7 @@ def test_cleanup_isolates_malformed_review_observation(
     failed_change_id, cleaned_change_id = (revision.change_id for revision in stack.revisions)
     state_store = ReviewStateStore.for_repo(repo)
     initial_state = state_store.load()
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
     failed_identity = initial_state.review_identities[failed_change_id]
     cleaned_identity = initial_state.review_identities[cleaned_change_id]
     fake_repo.pull_requests[failed_identity.pr_number].state = "closed"
@@ -351,7 +351,7 @@ def test_cleanup_removes_overview_comment_for_closed_pull_request(
     change_id = stack.revisions[-1].change_id
     state_store = ReviewStateStore.for_repo(repo)
     fake_repo.pull_requests[2].state = "closed"
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
     fake_repo.create_issue_comment(
         body=f"{STACK_OVERVIEW_COMMENT_MARKER}\nstack overview",
         issue_number=2,

--- a/tests/integration/test_list_command.py
+++ b/tests/integration/test_list_command.py
@@ -258,7 +258,7 @@ def test_list_inventories_paths_that_share_a_reviewed_prefix(
     run_command(["jj", "new", shared.commit_id], repo)
     commit_file(repo, "right", "right.txt")
     right = selected_stack(repo).head
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
     assert run_main(repo, config_path, "submit") == 0
     capsys.readouterr()
 

--- a/tests/integration/test_merge_command.py
+++ b/tests/integration/test_merge_command.py
@@ -8,7 +8,7 @@ from jj_stack.github.client import GithubClient, GithubClientError
 from jj_stack.jj.client import JjClient
 from jj_stack.state.store import ReviewStateStore
 
-from ..support.fake_github import FakeGithubState, _complete_async_merge, create_app
+from ..support.fake_github import FakeGithubState, _complete_stack_merge, create_app
 from ..support.integration_helpers import (
     commit_file,
     init_fake_github_repo_with_submitted_feature,
@@ -75,7 +75,7 @@ def test_merge_draft_blocks_the_candidate_prefix(
     assert read_remote_ref(fake_repo.git_dir, "main") == trunk_before
 
 
-def test_native_merge_rebases_an_explicit_prefix_and_rewrites_the_survivor(
+def test_stack_merge_rebases_an_explicit_prefix_and_rewrites_the_survivor(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -83,7 +83,7 @@ def test_native_merge_rebases_an_explicit_prefix_and_rewrites_the_survivor(
     repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=3)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     fake_repo.allow_rebase_merge = True
-    fake_repo.native_stacks = {7: (1, 2, 3)}
+    fake_repo.github_stacks = {7: (1, 2, 3)}
     fake_repo.pull_requests[3].state = "closed"
     state_store = ReviewStateStore.for_repo(repo)
     stack_before = selected_stack(repo)
@@ -102,8 +102,8 @@ def test_native_merge_rebases_an_explicit_prefix_and_rewrites_the_survivor(
     captured = capsys.readouterr()
 
     assert exit_code == 0, (captured.out, captured.err)
-    assert fake_repo.async_merge_requests == [(2, "rebase", stack_before.revisions[1].commit_id)]
-    assert fake_repo.async_merge_polls == [(2, "fake-async-1")]
+    assert fake_repo.stack_merge_requests == [(2, "rebase", stack_before.revisions[1].commit_id)]
+    assert fake_repo.stack_merge_polls == [(2, "fake-stack-merge-1")]
     assert fake_repo.pull_requests[1].state == "closed"
     assert fake_repo.pull_requests[2].state == "closed"
     assert fake_repo.pull_requests[3].state == "closed"
@@ -118,7 +118,7 @@ def test_native_merge_rebases_an_explicit_prefix_and_rewrites_the_survivor(
     )
 
 
-def test_native_merge_commit_uses_one_group_result_that_sync_can_retire(
+def test_stack_merge_commit_uses_one_group_result_that_sync_can_retire(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -126,7 +126,7 @@ def test_native_merge_commit_uses_one_group_result_that_sync_can_retire(
     repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     fake_repo.allow_merge_commit = True
-    fake_repo.native_stacks = {7: (1, 2)}
+    fake_repo.github_stacks = {7: (1, 2)}
     state_store = ReviewStateStore.for_repo(repo)
     stack = selected_stack(repo)
 
@@ -156,14 +156,14 @@ def test_native_merge_commit_uses_one_group_result_that_sync_can_retire(
     assert JjClient(repo).resolve_revision("@").only_parent_commit_id() == merge_commit
 
 
-def test_native_merge_terminal_failure_is_atomic(
+def test_stack_merge_terminal_failure_is_atomic(
     tmp_path: Path,
     monkeypatch,
     capsys,
 ) -> None:
     repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    fake_repo.native_stacks = {7: (1, 2)}
+    fake_repo.github_stacks = {7: (1, 2)}
     fake_repo.unmergeable_pull_numbers.add(2)
     state_store = ReviewStateStore.for_repo(repo)
     state_before = state_store.load()
@@ -183,19 +183,19 @@ def test_native_merge_terminal_failure_is_atomic(
     assert "rebase onto" in normalized
     assert "resolve the conflict" in normalized
     assert "jj-stack submit" in normalized
-    assert fake_repo.async_merge_requests
-    assert fake_repo.async_merge_polls == [(2, "fake-async-1")]
+    assert fake_repo.stack_merge_requests
+    assert fake_repo.stack_merge_polls == [(2, "fake-stack-merge-1")]
     assert tuple(pr.state for pr in fake_repo.pull_requests.values()) == ("open", "open")
     assert tuple(
         fake_repo.ref_target(pr.head_ref) for pr in fake_repo.pull_requests.values()
     ) == (heads_before)
-    assert fake_repo.native_stacks == {7: (1, 2)}
+    assert fake_repo.github_stacks == {7: (1, 2)}
     assert read_remote_ref(fake_repo.git_dir, "main") == trunk_before
     assert state_store.load() == state_before
 
 
 @pytest.mark.parametrize("dry_run", (False, True))
-def test_native_merge_reobserves_lower_heads_before_request(
+def test_stack_merge_reobserves_lower_heads_before_request(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -204,7 +204,7 @@ def test_native_merge_reobserves_lower_heads_before_request(
     repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     fake_repo.auto_merge_reachable_heads = False
-    fake_repo.native_stacks = {7: (1, 2)}
+    fake_repo.github_stacks = {7: (1, 2)}
     trunk_before = read_remote_ref(fake_repo.git_dir, "main")
     app = create_app(FakeGithubState.single_repository(fake_repo))
 
@@ -231,19 +231,19 @@ def test_native_merge_reobserves_lower_heads_before_request(
 
     assert exit_code == 1
     assert "last submitted commit" in captured.err
-    assert fake_repo.async_merge_requests == []
+    assert fake_repo.stack_merge_requests == []
     assert tuple(pr.state for pr in fake_repo.pull_requests.values()) == ("open", "open")
     assert read_remote_ref(fake_repo.git_dir, "main") == trunk_before
 
 
-def test_native_merge_recovers_only_from_a_terminal_retry(
+def test_stack_merge_recovers_only_from_a_terminal_retry(
     tmp_path: Path,
     monkeypatch,
     capsys,
 ) -> None:
     repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    fake_repo.native_stacks = {7: (1, 2)}
+    fake_repo.github_stacks = {7: (1, 2)}
     state_store = ReviewStateStore.for_repo(repo)
     state_before = state_store.load()
     app = create_app(FakeGithubState.single_repository(fake_repo))
@@ -272,7 +272,7 @@ def test_native_merge_recovers_only_from_a_terminal_retry(
     )
     assert run_main(repo, config_path, "merge") != 0
     capsys.readouterr()
-    assert fake_repo.async_merge_polls == []
+    assert fake_repo.stack_merge_polls == []
     assert tuple(pr.state for pr in fake_repo.pull_requests.values()) == ("open", "open")
 
     patch_github_client_builders(
@@ -284,28 +284,28 @@ def test_native_merge_recovers_only_from_a_terminal_retry(
     assert run_main(repo, config_path, "merge") == 1
     pending = capsys.readouterr()
     assert "matching request is already pending" in pending.out
-    assert fake_repo.async_merge_polls == []
+    assert fake_repo.stack_merge_polls == []
     assert tuple(pr.state for pr in fake_repo.pull_requests.values()) == ("open", "open")
 
-    _complete_async_merge(fake_repo, fake_repo.async_merge_operations[2])
+    _complete_stack_merge(fake_repo, fake_repo.stack_merge_operations[2])
     assert tuple(pr.state for pr in fake_repo.pull_requests.values()) == ("closed", "closed")
     assert run_main(repo, config_path, "merge") == 0
     completed = capsys.readouterr()
     assert "final trunk commit" in completed.out
-    assert fake_repo.async_merge_polls == []
-    assert len(fake_repo.async_merge_requests) == 1
+    assert fake_repo.stack_merge_polls == []
+    assert len(fake_repo.stack_merge_requests) == 1
     assert tuple(pr.state for pr in fake_repo.pull_requests.values()) == ("closed", "closed")
     assert state_store.load() == state_before
 
 
-def test_native_merge_requires_a_resource_for_a_multi_pr_review(
+def test_stack_merge_requires_a_resource_for_a_multi_pr_review(
     tmp_path: Path,
     monkeypatch,
     capsys,
 ) -> None:
     repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
     state_store = ReviewStateStore.for_repo(repo)
     state_before = state_store.load()
     trunk_before = read_remote_ref(fake_repo.git_dir, "main")
@@ -314,8 +314,8 @@ def test_native_merge_requires_a_resource_for_a_multi_pr_review(
     captured = capsys.readouterr()
 
     assert exit_code == 1
-    assert "did not report a native stack" in captured.err
-    assert fake_repo.async_merge_requests == []
+    assert "did not report a stack" in captured.err
+    assert fake_repo.stack_merge_requests == []
     assert tuple(pr.state for pr in fake_repo.pull_requests.values()) == ("open", "open")
     assert read_remote_ref(fake_repo.git_dir, "main") == trunk_before
     assert state_store.load() == state_before
@@ -336,7 +336,7 @@ def test_ordinary_merge_methods_create_distinct_commit_topology(
         config_path = configure_submit_environment(monkeypatch, method_path, fake_repo)
         fake_repo.allow_merge_commit = True
         fake_repo.allow_rebase_merge = True
-        fake_repo.native_stacks = {}
+        fake_repo.github_stacks = {}
         pull_request = fake_repo.pull_requests[1]
         head_before = fake_repo.ref_target(pull_request.head_ref)
         trunk_before = fake_repo.ref_target("main")

--- a/tests/integration/test_submit_command.py
+++ b/tests/integration/test_submit_command.py
@@ -79,13 +79,13 @@ def _assert_stack_pull_requests_match_dag(
         assert pull_request.base_ref == expected_base
 
 
-def test_submit_keeps_one_pr_ordinary_until_native_stack_is_needed(
+def test_submit_keeps_one_pr_ordinary_until_github_stack_is_needed(
     tmp_path: Path,
     monkeypatch,
     capsys,
 ) -> None:
     repo, fake_repo = init_fake_github_repo(tmp_path)
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     commit_file(repo, "feature 1", "feature-1.txt")
 
@@ -93,7 +93,7 @@ def test_submit_keeps_one_pr_ordinary_until_native_stack_is_needed(
     capsys.readouterr()
 
     assert tuple(fake_repo.pull_requests) == (1,)
-    assert fake_repo.native_stacks == {}
+    assert fake_repo.github_stacks == {}
     assert issue_comments(fake_repo, 1) == []
 
     commit_file(repo, "feature 2", "feature-2.txt")
@@ -101,17 +101,17 @@ def test_submit_keeps_one_pr_ordinary_until_native_stack_is_needed(
     capsys.readouterr()
 
     assert tuple(fake_repo.pull_requests) == (1, 2)
-    assert fake_repo.native_stacks == {1: (1, 2)}
+    assert fake_repo.github_stacks == {1: (1, 2)}
     assert all(issue_comments(fake_repo, number) == [] for number in (1, 2))
 
 
-def test_submit_native_stack_recovers_lost_create_and_retries_blocked_append(
+def test_submit_github_stack_recovers_lost_create_and_retries_blocked_append(
     tmp_path: Path,
     monkeypatch,
     capsys,
 ) -> None:
     repo, fake_repo = init_fake_github_repo(tmp_path)
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     commit_file(repo, "feature 1", "feature-1.txt")
     commit_file(repo, "feature 2", "feature-2.txt")
@@ -143,7 +143,7 @@ def test_submit_native_stack_recovers_lost_create_and_retries_blocked_append(
 
     assert run_main(repo, config_path, "submit") == EXIT_GITHUB
     assert "jj-stack submit" in capsys.readouterr().err
-    assert fake_repo.native_stacks == {1: (1, 2)}
+    assert fake_repo.github_stacks == {1: (1, 2)}
     assert len(state_store.load().review_identities) == 2
 
     top_change_id = selected_stack(repo).revisions[-1].change_id
@@ -152,34 +152,34 @@ def test_submit_native_stack_recovers_lost_create_and_retries_blocked_append(
         repo,
     )
     stack_description = tmp_path / "stack.md"
-    write_file(stack_description, "Native stack overview\n")
+    write_file(stack_description, "GitHub stack overview\n")
 
     assert run_main(repo, config_path, "submit", "--describe", f"stack={stack_description}") == 0
     assert fake_repo.pull_requests[2].title == "feature 2 renamed"
     assert fake_repo.pull_requests[2].body == "updated body"
-    assert "Native stack overview" in _overview_comments(fake_repo, 2)[0].body
+    assert "GitHub stack overview" in _overview_comments(fake_repo, 2)[0].body
 
     for number in range(3, 6):
         commit_file(repo, f"feature {number}", f"feature-{number}.txt")
     assert run_main(repo, config_path, "submit") == EXIT_GITHUB
-    assert fake_repo.native_stacks == {1: (1, 2)}
+    assert fake_repo.github_stacks == {1: (1, 2)}
     fake_repo.pull_requests[3].is_queued = False
     assert run_main(repo, config_path, "submit") == 0
 
-    assert (fake_repo.native_stacks, appended) == (
+    assert (fake_repo.github_stacks, appended) == (
         {1: (1, 2, 3, 4, 5)},
         [(3, 4, 5), (3, 4, 5)],
     )
 
 
-def test_submit_recreates_native_stack_only_after_active_review_grows_to_two(
+def test_submit_recreates_github_stack_only_after_active_review_grows_to_two(
     tmp_path: Path,
     monkeypatch,
     capsys,
 ) -> None:
     repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    fake_repo.native_stacks = {7: (1, 2)}
+    fake_repo.github_stacks = {7: (1, 2)}
     fake_repo.apply_squash_merge(fake_repo.pull_requests[1])
     run_command(["jj", "git", "fetch", "--remote", "origin"], repo)
     active_change_id = selected_stack(repo).head.change_id
@@ -189,14 +189,14 @@ def test_submit_recreates_native_stack_only_after_active_review_grows_to_two(
     captured = capsys.readouterr()
 
     assert exit_code == 0, (captured.out, captured.err)
-    assert fake_repo.native_stacks == {}
+    assert fake_repo.github_stacks == {}
     assert fake_repo.pull_requests[1].merged_at is not None
     assert fake_repo.pull_requests[2].state == "open"
     assert fake_repo.pull_requests[2].base_ref == "main"
 
     commit_file(repo, "feature 3", "feature-3.txt")
     assert run_main(repo, config_path, "submit") == 0
-    assert fake_repo.native_stacks == {2: (2, 3)}
+    assert fake_repo.github_stacks == {2: (2, 3)}
 
 
 def test_submit_appends_to_active_suffix_after_historical_prefix(
@@ -206,12 +206,12 @@ def test_submit_appends_to_active_suffix_after_historical_prefix(
 ) -> None:
     repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    fake_repo.native_stacks = {7: (1, 2)}
+    fake_repo.github_stacks = {7: (1, 2)}
     fake_repo.apply_squash_merge(fake_repo.pull_requests[1])
     fake_repo.update_pull_request_base(
         fake_repo.pull_requests[2],
         base_ref="main",
-        reason="native_merge",
+        reason="github_stack_merge",
     )
     run_command(["jj", "git", "fetch", "--remote", "origin"], repo)
     active_change_id = selected_stack(repo).head.change_id
@@ -222,7 +222,7 @@ def test_submit_appends_to_active_suffix_after_historical_prefix(
     captured = capsys.readouterr()
 
     assert exit_code == 0, (captured.out, captured.err)
-    assert fake_repo.native_stacks == {7: (1, 2, 3)}
+    assert fake_repo.github_stacks == {7: (1, 2, 3)}
     assert fake_repo.pull_requests[1].merged_at is not None
     assert fake_repo.pull_requests[2].base_ref == "main"
     assert fake_repo.pull_requests[3].base_ref == fake_repo.pull_requests[2].head_ref
@@ -234,7 +234,7 @@ def test_submit_retargets_stale_review_bases_before_pushing_reordered_stack(
     capsys,
 ) -> None:
     repo, fake_repo = init_fake_github_repo(tmp_path)
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     commit_file(repo, "feature 1", "feature-1.txt")
     commit_file(repo, "feature 2", "feature-2.txt")
@@ -260,7 +260,7 @@ def test_submit_retargets_stale_review_bases_before_pushing_reordered_stack(
         for revision in reordered_stack.revisions
     }
     assert all(pull_request.state == "open" for pull_request in fake_repo.pull_requests.values())
-    assert (len(fake_repo.pull_requests), fake_repo.native_stacks) == (
+    assert (len(fake_repo.pull_requests), fake_repo.github_stacks) == (
         4,
         {2: (2, 3, 4, 1)},
     )
@@ -270,13 +270,13 @@ def test_submit_retargets_stale_review_bases_before_pushing_reordered_stack(
     assert fake_repo.pull_requests[1].base_ref == bookmarks_by_subject["feature 4"]
 
 
-def test_submit_native_preflight_failures_recover_without_persisted_phase(
+def test_submit_stack_preflight_failures_recover_without_persisted_phase(
     tmp_path: Path,
     monkeypatch,
     capsys,
 ) -> None:
     repo, fake_repo = init_fake_github_repo(tmp_path)
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     commit_file(repo, "feature 1", "feature-1.txt")
     commit_file(repo, "feature 2", "feature-2.txt")
@@ -323,19 +323,124 @@ def test_submit_native_preflight_failures_recover_without_persisted_phase(
     remote_before = remote_refs(fake_repo.git_dir)
 
     assert run_main(repo, config_path, "submit", "--dry-run", reordered_head) == 0
-    assert fake_repo.native_stacks == {1: (1, 2)}
+    assert fake_repo.github_stacks == {1: (1, 2)}
     assert run_main(repo, config_path, "submit", reordered_head) == EXIT_GITHUB
 
     assert ReviewStateStore.for_repo(repo).load() == state_before
     assert remote_refs(fake_repo.git_dir) == remote_before
-    assert fake_repo.native_stacks == {}
+    assert fake_repo.github_stacks == {}
 
     failure = "none"
     assert run_main(repo, config_path, "submit", reordered_head) == 0
     assert ReviewStateStore.for_repo(repo).load().review_identities.keys() == (
         state_before.review_identities.keys()
     )
-    assert fake_repo.native_stacks == {2: (2, 1)}
+    assert fake_repo.github_stacks == {2: (2, 1)}
+
+
+def test_submit_rechecks_github_stack_membership_before_mutating_reviews(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
+    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
+    stack = selected_stack(repo)
+    top_change_id = stack.revisions[-1].change_id
+    run_command(
+        ["jj", "describe", "-r", top_change_id, "-m", "feature 2 rewritten"],
+        repo,
+    )
+
+    state_store = ReviewStateStore.for_repo(repo)
+    state_before = state_store.load()
+    review_branches = tuple(
+        identity.head_ref for identity in state_before.review_identities.values()
+    )
+    review_refs_before = {
+        branch: read_remote_ref(fake_repo.git_dir, branch) for branch in review_branches
+    }
+    pull_requests_before = {
+        number: (
+            pull_request.base_ref,
+            pull_request.body,
+            pull_request.head_ref,
+            pull_request.title,
+        )
+        for number, pull_request in fake_repo.pull_requests.items()
+    }
+    comments_before = {
+        number: tuple(comment.body for comment in issue_comments(fake_repo, number))
+        for number in fake_repo.pull_requests
+    }
+    stack_number = next(iter(fake_repo.github_stacks))
+    app = create_app(FakeGithubState.single_repository(fake_repo))
+    observations = 0
+
+    class ConcurrentAppendClient(GithubClient):
+        async def list_stacks(self):
+            nonlocal observations
+            observed = await super().list_stacks()
+            observations += 1
+            if observations == 1:
+                top_pull_request = fake_repo.pull_requests[2]
+                dependent_branch = "external/dependent"
+                run_command(
+                    [
+                        "git",
+                        "--git-dir",
+                        str(fake_repo.git_dir),
+                        "update-ref",
+                        f"refs/heads/{dependent_branch}",
+                        top_pull_request.head_sha,
+                    ],
+                    fake_repo.git_dir.parent,
+                )
+                dependent = fake_repo.create_pull_request(
+                    base_ref=top_pull_request.head_ref,
+                    body="external dependent",
+                    head_ref=dependent_branch,
+                    title="external dependent",
+                )
+                fake_repo.github_stacks[stack_number] = (
+                    *fake_repo.github_stacks[stack_number],
+                    dependent.number,
+                )
+            return observed
+
+    patch_github_client_builders(
+        monkeypatch,
+        app=app,
+        fake_repo=fake_repo,
+        modules=("jj_stack.commands.submit.command",),
+        client_type=ConcurrentAppendClient,
+    )
+    fake_repo.pull_request_events.clear()
+
+    assert run_main(repo, config_path, "submit") == 1
+    captured = capsys.readouterr()
+
+    assert "keeps #3 active outside the selected stack" in captured.err
+    assert observations == 2
+    assert state_store.load() == state_before
+    assert {
+        branch: read_remote_ref(fake_repo.git_dir, branch) for branch in review_branches
+    } == review_refs_before
+    assert {
+        number: (
+            fake_repo.pull_requests[number].base_ref,
+            fake_repo.pull_requests[number].body,
+            fake_repo.pull_requests[number].head_ref,
+            fake_repo.pull_requests[number].title,
+        )
+        for number in pull_requests_before
+    } == pull_requests_before
+    assert {
+        number: tuple(comment.body for comment in issue_comments(fake_repo, number))
+        for number in pull_requests_before
+    } == comments_before
+    assert fake_repo.pull_request_events == []
+    assert fake_repo.github_stacks == {stack_number: (1, 2, 3)}
 
 
 def test_submit_opens_new_pr_when_middle_change_is_split_in_two(
@@ -396,7 +501,7 @@ def test_submit_opens_new_pr_when_middle_change_is_split_in_two(
     assert len(fake_repo.pull_requests) == 4
 
 
-def test_submit_squash_blocks_until_old_native_stack_is_dissolved(
+def test_submit_squash_blocks_until_old_github_stack_is_dissolved(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -459,7 +564,7 @@ def test_submit_squash_blocks_until_old_native_stack_is_dissolved(
     assert len(fake_repo.pull_requests) == 3
 
 
-def test_submit_split_path_blocks_until_old_native_stack_is_dissolved(
+def test_submit_split_path_blocks_until_old_github_stack_is_dissolved(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -866,7 +971,7 @@ def test_submit_dry_run_does_not_mutate_local_remote_or_github_state(
     capsys,
 ) -> None:
     repo, fake_repo = init_fake_github_repo(tmp_path)
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     commit_file(repo, "feature 1", "feature-1.txt")
     commit_file(repo, "feature 2", "feature-2.txt")
@@ -965,7 +1070,7 @@ def test_submit_moves_overview_comment_when_stack_head_advances(
     capsys,
 ) -> None:
     repo, fake_repo = init_fake_github_repo(tmp_path)
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     commit_file(repo, "feature 1", "feature-1.txt")
     commit_file(repo, "feature 2", "feature-2.txt")
@@ -1519,7 +1624,7 @@ def test_submit_checkpoints_successful_in_flight_pull_request_before_failure(
     capsys,
 ) -> None:
     repo, fake_repo = init_fake_github_repo(tmp_path)
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     commit_file(repo, "feature 1", "feature-1.txt")
     commit_file(repo, "feature 2", "feature-2.txt")
@@ -1574,7 +1679,7 @@ def test_submit_checkpoints_successful_in_flight_pull_request_before_failure(
     assert change_id_1 in state.submitted_baselines
     assert change_id_2 not in state.review_identities
     assert change_id_2 not in state.submitted_baselines
-    assert len(fake_repo.pull_requests) == 1 and fake_repo.native_stacks == {}
+    assert len(fake_repo.pull_requests) == 1 and fake_repo.github_stacks == {}
     assert fake_repo.pull_requests[1].title == "feature 1"
     pushed_review_refs = {
         ref: target

--- a/tests/integration/test_sync_command.py
+++ b/tests/integration/test_sync_command.py
@@ -35,12 +35,12 @@ pytestmark = pytest.mark.merge_recovery
 def _squash_merge_pull_request(fake_repo, pull_number: int) -> None:
     stack_number = fake_repo.stack_number_for_pull(pull_number)
     if stack_number is not None:
-        del fake_repo.native_stacks[stack_number]
+        del fake_repo.github_stacks[stack_number]
     fake_repo.apply_squash_merge(fake_repo.pull_requests[pull_number])
 
 
-def _simulate_native_partial_merge(fake_repo) -> str:
-    fake_repo.native_stacks = {7: (1, 2)}
+def _simulate_stack_partial_merge(fake_repo) -> str:
+    fake_repo.github_stacks = {7: (1, 2)}
     fake_repo.apply_squash_merge(fake_repo.pull_requests[1])
     return fake_repo.rewrite_pull_request_onto_base(
         fake_repo.pull_requests[2],
@@ -205,7 +205,7 @@ def test_sync_all_reports_a_failed_tracking_removal_in_its_exit_status(
     assert on_trunk.change_id in ReviewStateStore.for_repo(repo).load().review_identities
 
 
-def test_sync_converges_native_history_and_adopts_rewritten_survivor(
+def test_sync_converges_stack_history_and_adopts_rewritten_survivor(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -214,7 +214,7 @@ def test_sync_converges_native_history_and_adopts_rewritten_survivor(
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     state_store = ReviewStateStore.for_repo(repo)
     on_trunk, survivor = selected_stack(repo).revisions
-    remote_survivor = _simulate_native_partial_merge(fake_repo)
+    remote_survivor = _simulate_stack_partial_merge(fake_repo)
 
     exit_code = run_main(repo, config_path, "sync", survivor.change_id)
     captured = capsys.readouterr()
@@ -237,7 +237,7 @@ def test_sync_converges_native_history_and_adopts_rewritten_survivor(
     )
     assert fake_repo.pull_requests[2].head_sha == rewritten_survivor.commit_id
     assert fake_repo.pull_requests[2].base_ref == "main"
-    assert fake_repo.native_stacks == {7: (1, 2)}
+    assert fake_repo.github_stacks == {7: (1, 2)}
     on_trunk_versions = JjClient(repo).query_revisions_by_change_ids((on_trunk.change_id,))[
         on_trunk.change_id
     ]
@@ -255,7 +255,7 @@ def test_sync_converges_native_history_and_adopts_rewritten_survivor(
     assert fake_repo.pull_requests[2].head_sha == drifted_head
 
 
-def test_sync_preserves_unpublished_edits_to_an_active_native_survivor(
+def test_sync_preserves_unpublished_edits_to_an_active_stack_survivor(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -264,7 +264,7 @@ def test_sync_preserves_unpublished_edits_to_an_active_native_survivor(
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     state_store = ReviewStateStore.for_repo(repo)
     on_trunk, survivor = selected_stack(repo).revisions
-    _simulate_native_partial_merge(fake_repo)
+    _simulate_stack_partial_merge(fake_repo)
     state_before = state_store.load()
     run_command(["jj", "edit", survivor.change_id], repo)
     write_file(repo / "local-survivor-edit.txt", "keep this edit\n")
@@ -283,7 +283,7 @@ def test_sync_preserves_unpublished_edits_to_an_active_native_survivor(
     assert state_store.load() == state_before
 
 
-def test_sync_reports_a_closed_native_survivor_as_a_closed_review_not_branch_drift(
+def test_sync_reports_a_closed_stack_survivor_as_a_closed_review_not_branch_drift(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -294,7 +294,7 @@ def test_sync_reports_a_closed_native_survivor_as_a_closed_review_not_branch_dri
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     state_store = ReviewStateStore.for_repo(repo)
     on_trunk, survivor = selected_stack(repo).revisions
-    _simulate_native_partial_merge(fake_repo)
+    _simulate_stack_partial_merge(fake_repo)
     fake_repo.pull_requests[2].state = "closed"
     state_before = state_store.load()
 
@@ -310,7 +310,7 @@ def test_sync_reports_a_closed_native_survivor_as_a_closed_review_not_branch_dri
     assert state_store.load() == state_before
 
 
-def test_sync_retries_native_adoption_after_survivor_submit_fails(
+def test_sync_retries_stack_adoption_after_survivor_submit_fails(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -320,7 +320,7 @@ def test_sync_retries_native_adoption_after_survivor_submit_fails(
     state_store = ReviewStateStore.for_repo(repo)
     on_trunk, survivor = selected_stack(repo).revisions
     baseline_before = state_store.load().submitted_baselines[survivor.change_id]
-    remote_survivor = _simulate_native_partial_merge(fake_repo)
+    remote_survivor = _simulate_stack_partial_merge(fake_repo)
     real_run_submit = sync_command.run_submit_async
 
     async def fail_submit(**_kwargs):
@@ -348,7 +348,7 @@ def test_sync_retries_native_adoption_after_survivor_submit_fails(
     assert recovered_state.submitted_baselines[survivor.change_id].commit_id == remote_survivor
 
 
-def test_sync_checks_native_branch_drift_before_rewriting_local_history(
+def test_sync_checks_stack_branch_drift_before_rewriting_local_history(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -357,7 +357,7 @@ def test_sync_checks_native_branch_drift_before_rewriting_local_history(
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     state_store = ReviewStateStore.for_repo(repo)
     on_trunk, survivor = selected_stack(repo).revisions
-    _simulate_native_partial_merge(fake_repo)
+    _simulate_stack_partial_merge(fake_repo)
     state_before = state_store.load()
     require_targets = JjClient._require_remote_branch_targets_at_url
     drifted = False
@@ -394,7 +394,7 @@ def test_sync_checks_native_branch_drift_before_rewriting_local_history(
     assert (review_temp.ref_target, review_temp.bookmark_targets) == (None, ())
 
 
-def test_sync_retries_native_adoption_after_post_apply_branch_drift(
+def test_sync_retries_stack_adoption_after_post_apply_branch_drift(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -403,7 +403,7 @@ def test_sync_retries_native_adoption_after_post_apply_branch_drift(
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     state_store = ReviewStateStore.for_repo(repo)
     on_trunk, survivor = selected_stack(repo).revisions
-    first_remote_survivor = _simulate_native_partial_merge(fake_repo)
+    first_remote_survivor = _simulate_stack_partial_merge(fake_repo)
     require_targets = JjClient._require_remote_branch_targets_at_url
     checks = 0
     second_remote_survivor: str | None = None
@@ -463,7 +463,7 @@ def test_sync_retries_native_adoption_after_post_apply_branch_drift(
     )
 
 
-def test_sync_all_requires_terminal_merge_for_exact_native_member(
+def test_sync_all_requires_terminal_stack_merge_for_exact_stack_member(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -473,7 +473,7 @@ def test_sync_all_requires_terminal_merge_for_exact_native_member(
     first, second = selected_stack(repo).revisions
     state_store = ReviewStateStore.for_repo(repo)
     second_baseline = state_store.load().submitted_baselines[second.change_id]
-    fake_repo.native_stacks = {7: (1, 2)}
+    fake_repo.github_stacks = {7: (1, 2)}
     fake_repo.auto_merge_reachable_heads = False
     update_remote_ref(fake_repo, branch="main", target=first.commit_id)
 
@@ -521,10 +521,10 @@ def test_sync_all_requires_terminal_merge_for_exact_native_member(
     assert selected_exit == 0, (selected.out, selected.err)
     assert first.change_id not in state_store.load().review_identities
     assert state_store.load().submitted_baselines[second.change_id].commit_id == remote_survivor
-    assert fake_repo.native_stacks == {7: (1, 2)}
+    assert fake_repo.github_stacks == {7: (1, 2)}
 
 
-def test_sync_does_not_trust_active_native_head_drift_without_merged_history(
+def test_sync_does_not_trust_active_stack_head_drift_without_merged_history(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -534,7 +534,7 @@ def test_sync_does_not_trust_active_native_head_drift_without_merged_history(
     state_store = ReviewStateStore.for_repo(repo)
     _first, second = selected_stack(repo).revisions
     baseline = state_store.load().submitted_baselines[second.change_id]
-    fake_repo.native_stacks = {7: (1, 2)}
+    fake_repo.github_stacks = {7: (1, 2)}
     drifted_head = fake_repo.force_push_pull_request_head(fake_repo.pull_requests[2])
 
     exit_code = run_main(repo, config_path, "sync", second.change_id)
@@ -767,7 +767,7 @@ def test_sync_all_isolates_an_unavailable_snapshot_from_an_exact_review(
     write_file(state_path, json.dumps(raw_state))
 
     fake_repo.auto_merge_reachable_heads = False
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
     update_remote_ref(fake_repo, branch="main", target=second.commit_id)
 
     exit_code = run_main(repo, config_path, "sync", "--all")

--- a/tests/integration/test_unstack_command.py
+++ b/tests/integration/test_unstack_command.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 import jj_stack.commands.unstack as unstack_module
-from jj_stack.commands._native_stack_safety import GithubStackSelection
+from jj_stack.commands._github_stack_safety import GithubStackSelection
 from jj_stack.errors import CliError
 from jj_stack.github.client import GithubClient, GithubClientError
 from jj_stack.github.overview_comments import STACK_OVERVIEW_COMMENT_MARKER
@@ -38,7 +38,7 @@ def _combined_output(captured) -> str:
     return " ".join((captured.out + " " + captured.err).split())
 
 
-def test_unstack_apply_closes_native_stack_and_preserves_exact_tracking(
+def test_unstack_apply_closes_github_stack_and_preserves_exact_tracking(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -53,10 +53,10 @@ def test_unstack_apply_closes_native_stack_and_preserves_exact_tracking(
     app = create_app(FakeGithubState.single_repository(fake_repo))
     operations: list[str] = []
     locked = True
-    fake_repo.native_stacks = {7: (1, 2)}
+    fake_repo.github_stacks = {7: (1, 2)}
     fake_repo.issue_comments.clear()
 
-    class NativeStackClient(GithubClient):
+    class GithubStackClient(GithubClient):
         async def unstack(self, *, stack_number):
             operations.append("unstack")
             return github_stack(1, 2) if locked else None
@@ -70,7 +70,7 @@ def test_unstack_apply_closes_native_stack_and_preserves_exact_tracking(
         app=app,
         fake_repo=fake_repo,
         modules=("jj_stack.commands.unstack", "jj_stack.review.status"),
-        client_type=NativeStackClient,
+        client_type=GithubStackClient,
     )
 
     dry_run_exit_code = run_main(repo, config_path, "unstack", "--dry-run", change_id)
@@ -114,7 +114,7 @@ def test_unstack_dissolves_resource_and_preserves_merged_pull_request_history(
     repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     stack = selected_stack(repo)
-    fake_repo.native_stacks = {7: (1, 2)}
+    fake_repo.github_stacks = {7: (1, 2)}
     fake_repo.pull_requests[1].state = "closed"
     fake_repo.pull_requests[1].merged_at = "2026-07-23T12:00:00Z"
 
@@ -123,12 +123,12 @@ def test_unstack_dissolves_resource_and_preserves_merged_pull_request_history(
 
     assert exit_code == 0
     assert "dissolve GitHub stack #7" in captured.out
-    assert fake_repo.native_stacks == {}
+    assert fake_repo.github_stacks == {}
     assert fake_repo.pull_requests[1].merged_at is not None
     assert fake_repo.pull_requests[2].state == "closed"
 
 
-def test_unstack_head_change_before_native_boundary_preserves_github_stack(
+def test_unstack_head_change_before_stack_boundary_preserves_github_stack(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -138,34 +138,34 @@ def test_unstack_head_change_before_native_boundary_preserves_github_stack(
     state_store = ReviewStateStore.for_repo(repo)
     initial_state = state_store.load()
     change_id = selected_stack(repo).head.change_id
-    fake_repo.native_stacks = {7: (1, 2)}
+    fake_repo.github_stacks = {7: (1, 2)}
     app = create_app(FakeGithubState.single_repository(fake_repo))
-    native_observations = 0
+    stack_observations = 0
     fresh_boundary_lookups = 0
-    native_mutations: list[int] = []
+    stack_mutations: list[int] = []
 
     class HeadRaceClient(GithubClient):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            self.native_observed = False
+            self.stack_observed = False
 
         async def list_stacks(self):
-            nonlocal native_observations
+            nonlocal stack_observations
             stacks = await super().list_stacks()
-            native_observations += 1
-            self.native_observed = True
+            stack_observations += 1
+            self.stack_observed = True
             return stacks
 
         async def get_pull_requests_by_numbers(self, *, pull_numbers):
             nonlocal fresh_boundary_lookups
-            if self.native_observed:
+            if self.stack_observed:
                 fresh_boundary_lookups += 1
                 fake_repo.pull_requests[1].head_ref = "jj-stack/moved-aaaaaaaa"
                 fake_repo.pull_requests[1].head_label = "octo-org:jj-stack/moved-aaaaaaaa"
             return await super().get_pull_requests_by_numbers(pull_numbers=pull_numbers)
 
         async def unstack(self, *, stack_number):
-            native_mutations.append(stack_number)
+            stack_mutations.append(stack_number)
             return await super().unstack(stack_number=stack_number)
 
     patch_github_client_builders(
@@ -181,10 +181,10 @@ def test_unstack_head_change_before_native_boundary_preserves_github_stack(
 
     assert exit_code == 1
     assert "live PR and head no longer uniquely match" in _combined_output(captured)
-    assert native_observations == 1
+    assert stack_observations == 1
     assert fresh_boundary_lookups == 1
-    assert native_mutations == []
-    assert fake_repo.native_stacks == {7: (1, 2)}
+    assert stack_mutations == []
+    assert fake_repo.github_stacks == {7: (1, 2)}
     assert all(pull_request.state == "open" for pull_request in fake_repo.pull_requests.values())
     assert state_store.load() == initial_state
 
@@ -380,7 +380,7 @@ def test_unstack_and_cleanup_match_dry_run_on_fully_untracked_stack(
         )
 
     async def fail_list_stacks(*args, **kwargs):
-        raise AssertionError("unstack should not inspect native stacks without a mutation")
+        raise AssertionError("unstack should not inspect GitHub stacks without a mutation")
 
     monkeypatch.setattr(
         "jj_stack.review.status.JjClient.fetch_remote",
@@ -431,7 +431,7 @@ def test_unstack_dry_run_leaves_remote_state_unchanged_and_reports_planned_actio
     stack = selected_stack(repo)
     change_id = stack.revisions[-1].change_id
     state_store = ReviewStateStore.for_repo(repo)
-    fake_repo.native_stacks = {7: (1, 2)}
+    fake_repo.github_stacks = {7: (1, 2)}
     fake_repo.issue_comments.clear()
     initial_state = state_store.load()
 
@@ -442,7 +442,7 @@ def test_unstack_dry_run_leaves_remote_state_unchanged_and_reports_planned_actio
     assert exit_code == 0
     assert "Planned close actions:" in captured.out
     assert "dissolve GitHub stack #7" in captured.out
-    assert fake_repo.native_stacks == {7: (1, 2)}
+    assert fake_repo.github_stacks == {7: (1, 2)}
     assert all(pull_request.state == "open" for pull_request in fake_repo.pull_requests.values())
     assert refreshed_state == initial_state
     assert all(issue_comments(fake_repo, number) == [] for number in (1, 2))
@@ -638,7 +638,7 @@ def test_unstack_cleanup_orphans_retries_base_after_dependent_closes(
     )
 
     run_command(["jj", "abandon", *change_ids], repo)
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
 
     dry_run_exit_code = run_main(
         repo,
@@ -707,11 +707,11 @@ def test_unstack_cleanup_orphans_continues_after_one_orphan_is_blocked(
     state_store = ReviewStateStore.for_repo(repo)
     fake_repo.pull_requests[2].base_ref = "main"
     run_command(["jj", "abandon", *change_ids], repo)
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
 
     async def dissolve_exact(selection, **_kwargs):
         if tuple(selection.pull_numbers) == (1,):
-            raise CliError("native stack includes an unselected pull request")
+            raise CliError("GitHub stack includes an unselected pull request")
         return None
 
     monkeypatch.setattr(GithubStackSelection, "dissolve_exact", dissolve_exact)
@@ -727,7 +727,7 @@ def test_unstack_cleanup_orphans_continues_after_one_orphan_is_blocked(
     captured = capsys.readouterr()
 
     assert exit_code == 1
-    assert "native stack includes an unselected pull request" in _combined_output(captured)
+    assert "GitHub stack includes an unselected pull request" in _combined_output(captured)
     assert fake_repo.pull_requests[1].state == "open"
     assert fake_repo.pull_requests[2].state == "closed"
     refreshed_state = state_store.load()
@@ -794,7 +794,7 @@ def test_unstack_cleanup_pull_request_closes_orphaned_pr(
 
     run_command(["jj", "abandon", orphaned_change_id], repo)
     fake_repo.pull_requests[orphaned_pr_number].state = "closed"
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
 
     exit_code = run_main(
         repo,
@@ -1065,7 +1065,7 @@ def test_unstack_cleanup_pull_request_keeps_tracking_when_cleanup_blocks(
     assert refreshed_state == initial_state
 
 
-def test_unstack_cleanup_pull_request_dry_run_rejects_partial_native_stack(
+def test_unstack_cleanup_pull_request_dry_run_rejects_partial_github_stack(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -1076,7 +1076,7 @@ def test_unstack_cleanup_pull_request_dry_run_rejects_partial_native_stack(
     stack = selected_stack(repo)
     bottom_change_id = stack.revisions[0].change_id
     state_store = ReviewStateStore.for_repo(repo)
-    fake_repo.native_stacks = {7: (1, 2)}
+    fake_repo.github_stacks = {7: (1, 2)}
     state = state_store.load()
     bottom_bookmark = state.review_identities[bottom_change_id].head_ref
     bottom_pr_number = state.review_identities[bottom_change_id].pr_number
@@ -1131,7 +1131,7 @@ def test_unstack_cleanup_pull_request_orphan_close_is_idempotent_after_branch_al
             ),
         ),
     )
-    fake_repo.native_stacks = {}
+    fake_repo.github_stacks = {}
 
     exit_code = run_main(
         repo,

--- a/tests/support/fake_github.py
+++ b/tests/support/fake_github.py
@@ -22,7 +22,7 @@ def github_stack(
     number: int = 7,
     historical_pull_numbers: tuple[int, ...] = (),
 ) -> GithubStack:
-    """Build a typed native stack response for focused client overrides."""
+    """Build a typed GitHub stack response for focused client overrides."""
 
     return GithubStack.model_validate(
         {
@@ -151,7 +151,7 @@ class FakeGithubPullRequestReview:
 
 
 @dataclass(slots=True)
-class FakeAsyncMergeOperation:
+class FakeStackMergeOperation:
     expected_head_sha: str
     merge_method: str
     pull_number: int
@@ -224,16 +224,16 @@ class FakeGithubRepository:
     allow_merge_commit: bool = False
     allow_rebase_merge: bool = False
     allow_squash_merge: bool = True
-    async_merge_operations: dict[int, FakeAsyncMergeOperation] = field(default_factory=dict)
-    async_merge_polls: list[tuple[int, str]] = field(default_factory=list)
-    async_merge_requests: list[tuple[int, str, str]] = field(default_factory=list)
+    stack_merge_operations: dict[int, FakeStackMergeOperation] = field(default_factory=dict)
+    stack_merge_polls: list[tuple[int, str]] = field(default_factory=list)
+    stack_merge_requests: list[tuple[int, str, str]] = field(default_factory=list)
     auto_merge_reachable_heads: bool = True
     next_issue_comment_id: int = 1
-    next_native_stack_number: int = 1
+    next_github_stack_number: int = 1
     next_pull_request_number: int = 1
     next_pull_request_review_id: int = 1
     issue_comments: dict[int, list[FakeGithubIssueComment]] = field(default_factory=dict)
-    native_stacks: dict[int, tuple[int, ...]] = field(default_factory=dict)
+    github_stacks: dict[int, tuple[int, ...]] = field(default_factory=dict)
     pull_request_events: list[FakeGithubPullRequestEvent] = field(default_factory=list)
     pull_requests: dict[int, FakeGithubPullRequest] = field(default_factory=dict)
     pull_request_reviews: dict[int, list[FakeGithubPullRequestReview]] = field(
@@ -302,7 +302,7 @@ class FakeGithubRepository:
         return None
 
     def stack_number_for_pull(self, pull_number: int) -> int | None:
-        for stack_number, pull_numbers in self.native_stacks.items():
+        for stack_number, pull_numbers in self.github_stacks.items():
             if pull_number in pull_numbers:
                 return stack_number
         return None
@@ -480,7 +480,7 @@ class FakeGithubRepository:
         self,
         pull_requests: tuple[FakeGithubPullRequest, ...],
     ) -> str:
-        """Merge one PR or native PR prefix through a shared merge commit."""
+        """Merge one PR or stack PR prefix through a shared merge commit."""
 
         if not pull_requests:
             raise AssertionError("A merge commit requires at least one pull request.")
@@ -528,12 +528,12 @@ class FakeGithubRepository:
         *,
         base_ref: str,
     ) -> str:
-        """Model GitHub retargeting and replaying an active native survivor."""
+        """Model GitHub retargeting and replaying an active stack survivor."""
 
         heads = self.branch_heads()
         rewritten = self._replay_commit(
             commit_id=heads[pull_request.head_ref],
-            extra_header="x-fake-native-rewrite true",
+            extra_header="x-fake-stack-rewrite true",
             parent_commit_id=heads[base_ref],
         )
         self._run_backing_git(
@@ -544,7 +544,7 @@ class FakeGithubRepository:
         self.update_pull_request_base(
             pull_request,
             base_ref=base_ref,
-            reason="native_merge",
+            reason="github_stack_merge",
         )
         pull_request.head_sha = rewritten
         return rewritten
@@ -756,7 +756,7 @@ def create_app(fake_state: FakeGithubState) -> FastAPI:
         )
 
     _register_repository_routes(app, fake_state)
-    _register_native_stack_routes(app, fake_state)
+    _register_github_stack_routes(app, fake_state)
     _register_graphql_routes(app, fake_state)
     _register_pull_request_routes(app, fake_state)
     _register_issue_comment_routes(app, fake_state)
@@ -777,15 +777,15 @@ def _register_repository_routes(app: FastAPI, fake_state: FakeGithubState) -> No
         )
 
 
-def _register_native_stack_routes(app: FastAPI, fake_state: FakeGithubState) -> None:
-    """Register the observed native-stack routes."""
+def _register_github_stack_routes(app: FastAPI, fake_state: FakeGithubState) -> None:
+    """Register the observed stack routes."""
 
     @app.get("/repos/{owner}/{repo}/stacks")
     async def list_stacks(owner: str, repo: str) -> list[dict[str, object]]:
         repository = _get_repository(fake_state, owner, repo)
         return [
             _stack_payload(repository, number, members)
-            for number, members in sorted(_native_stacks(repository).items())
+            for number, members in sorted(_github_stacks(repository).items())
         ]
 
     @app.get("/repos/{owner}/{repo}/stacks/{stack_number}")
@@ -795,7 +795,7 @@ def _register_native_stack_routes(app: FastAPI, fake_state: FakeGithubState) -> 
         stack_number: int,
     ) -> dict[str, object]:
         repository = _get_repository(fake_state, owner, repo)
-        members = _native_stacks(repository).get(stack_number)
+        members = _github_stacks(repository).get(stack_number)
         if members is None:
             raise HTTPException(status_code=404, detail="Not Found")
         return _stack_payload(repository, stack_number, members)
@@ -812,7 +812,7 @@ def _register_native_stack_routes(app: FastAPI, fake_state: FakeGithubState) -> 
             raise HTTPException(status_code=422, detail="A stack requires two pull requests.")
         already = sorted(
             set(members).intersection(
-                member for existing in _native_stacks(repository).values() for member in existing
+                member for existing in _github_stacks(repository).values() for member in existing
             )
         )
         if already:
@@ -830,11 +830,11 @@ def _register_native_stack_routes(app: FastAPI, fake_state: FakeGithubState) -> 
             chained_members=members,
             complete_members=members,
         )
-        stacks = _native_stacks(repository)
-        number = repository.next_native_stack_number
+        stacks = _github_stacks(repository)
+        number = repository.next_github_stack_number
         while number in stacks:
             number += 1
-        repository.next_native_stack_number = number + 1
+        repository.next_github_stack_number = number + 1
         stacks[number] = members
         return _stack_payload(repository, number, members)
 
@@ -846,7 +846,7 @@ def _register_native_stack_routes(app: FastAPI, fake_state: FakeGithubState) -> 
         payload: Annotated[dict[str, object], Body(...)],
     ) -> dict[str, object]:
         repository = _get_repository(fake_state, owner, repo)
-        stacks = _native_stacks(repository)
+        stacks = _github_stacks(repository)
         existing = stacks.get(stack_number)
         added = _require_int_list(payload, "pull_requests")
         if existing is None:
@@ -873,7 +873,7 @@ def _register_native_stack_routes(app: FastAPI, fake_state: FakeGithubState) -> 
     )
     async def unstack(owner: str, repo: str, stack_number: int) -> Response:
         repository = _get_repository(fake_state, owner, repo)
-        stacks = _native_stacks(repository)
+        stacks = _github_stacks(repository)
         if stack_number not in stacks:
             raise HTTPException(status_code=404, detail="Not Found")
         del stacks[stack_number]
@@ -1089,32 +1089,32 @@ def _register_pull_request_routes(app: FastAPI, fake_state: FakeGithubState) -> 
         live_head = repository.ref_target(pull_request.head_ref)
         if live_head != expected_head_sha:
             raise HTTPException(status_code=400, detail="Target head changed.")
-        existing = repository.async_merge_operations.get(pull_number)
+        existing = repository.stack_merge_operations.get(pull_number)
         if existing is not None:
             if (
                 existing.expected_head_sha != expected_head_sha
                 or existing.merge_method != merge_method
             ):
-                return JSONResponse(_async_merge_payload(existing), status_code=409)
+                return JSONResponse(_stack_merge_payload(existing), status_code=409)
             status_code = 409 if existing.status == "pending" else 200
-            return JSONResponse(_async_merge_payload(existing), status_code=status_code)
+            return JSONResponse(_stack_merge_payload(existing), status_code=status_code)
         stack_number = repository.stack_number_for_pull(pull_number)
         if stack_number is None:
-            raise HTTPException(status_code=400, detail="Target is not a native stack member.")
+            raise HTTPException(status_code=400, detail="Target is not a GitHub stack member.")
         stack = GithubStack.model_validate(
-            _stack_payload(repository, stack_number, _native_stacks(repository)[stack_number])
+            _stack_payload(repository, stack_number, _github_stacks(repository)[stack_number])
         )
         if pull_number not in stack.active_pull_request_numbers or pull_request.is_draft:
             raise HTTPException(status_code=400, detail="Target is not mergeable.")
-        operation = FakeAsyncMergeOperation(
+        operation = FakeStackMergeOperation(
             expected_head_sha=expected_head_sha,
             merge_method=merge_method,
             pull_number=pull_number,
-            uuid=f"fake-async-{len(repository.async_merge_operations) + 1}",
+            uuid=f"fake-stack-merge-{len(repository.stack_merge_operations) + 1}",
         )
-        repository.async_merge_operations[pull_number] = operation
-        repository.async_merge_requests.append((pull_number, merge_method, expected_head_sha))
-        return JSONResponse(_async_merge_payload(operation), status_code=202)
+        repository.stack_merge_operations[pull_number] = operation
+        repository.stack_merge_requests.append((pull_number, merge_method, expected_head_sha))
+        return JSONResponse(_stack_merge_payload(operation), status_code=202)
 
     @app.get("/repos/{owner}/{repo}/pulls/{pull_number}/merge-async/{operation_uuid}")
     async def poll_stack_merge(
@@ -1124,13 +1124,13 @@ def _register_pull_request_routes(app: FastAPI, fake_state: FakeGithubState) -> 
         operation_uuid: str,
     ) -> dict[str, object]:
         repository = _get_repository(fake_state, owner, repo)
-        operation = repository.async_merge_operations.get(pull_number)
+        operation = repository.stack_merge_operations.get(pull_number)
         if operation is None or operation.uuid != operation_uuid:
             raise HTTPException(status_code=404, detail="Not Found")
-        repository.async_merge_polls.append((pull_number, operation_uuid))
+        repository.stack_merge_polls.append((pull_number, operation_uuid))
         if operation.status == "pending":
-            _complete_async_merge(repository, operation)
-        return _async_merge_payload(operation)
+            _complete_stack_merge(repository, operation)
+        return _stack_merge_payload(operation)
 
     @app.patch("/repos/{owner}/{repo}/issues/{issue_number}")
     async def update_issue(
@@ -1355,13 +1355,13 @@ def _require_int_list(payload: dict[str, object], key: str) -> tuple[int, ...]:
     return tuple(value)
 
 
-def _native_stacks(repository: FakeGithubRepository) -> dict[int, tuple[int, ...]]:
+def _github_stacks(repository: FakeGithubRepository) -> dict[int, tuple[int, ...]]:
     # GitHub refuses to put one pull request in two stacks: creating a second reports
     # "Pull requests #N are already part of a stack" (422, confirmed against the API). Tests
     # assign this mapping directly, so refuse the impossible shape here rather than let a fixture
     # justify production code defending against it.
     seen: set[int] = set()
-    for members in repository.native_stacks.values():
+    for members in repository.github_stacks.values():
         assert len(members) >= 2, (
             f"fake GitHub was given a one-member stack {members}, which GitHub rejects"
         )
@@ -1371,7 +1371,7 @@ def _native_stacks(repository: FakeGithubRepository) -> dict[int, tuple[int, ...
             "which GitHub rejects"
         )
         seen.update(members)
-    return repository.native_stacks
+    return repository.github_stacks
 
 
 def _stack_payload(
@@ -1408,7 +1408,7 @@ def _stack_pull_request_payload(
     }
 
 
-def _async_merge_payload(operation: FakeAsyncMergeOperation) -> dict[str, object]:
+def _stack_merge_payload(operation: FakeStackMergeOperation) -> dict[str, object]:
     return {
         "status": operation.status,
         "details": {
@@ -1421,17 +1421,17 @@ def _async_merge_payload(operation: FakeAsyncMergeOperation) -> dict[str, object
     }
 
 
-def _complete_async_merge(
+def _complete_stack_merge(
     repository: FakeGithubRepository,
-    operation: FakeAsyncMergeOperation,
+    operation: FakeStackMergeOperation,
 ) -> None:
     stack_number = repository.stack_number_for_pull(operation.pull_number)
     if stack_number is None:
         operation.status = "failed"
-        operation.message = "The native stack is no longer available."
+        operation.message = "The GitHub stack is no longer available."
         return
     stack = GithubStack.model_validate(
-        _stack_payload(repository, stack_number, _native_stacks(repository)[stack_number])
+        _stack_payload(repository, stack_number, _github_stacks(repository)[stack_number])
     )
     target_index = stack.active_pull_request_numbers.index(operation.pull_number)
     candidate_numbers = stack.active_pull_request_numbers[: target_index + 1]
@@ -1443,14 +1443,14 @@ def _complete_async_merge(
         for pull_request in candidates
     ):
         operation.status = "failed"
-        operation.message = "The native stack prefix is not mergeable."
+        operation.message = "The GitHub stack prefix is not mergeable."
         return
     for pull_request in candidates:
         if pull_request.base_ref != repository.default_branch:
             repository.update_pull_request_base(
                 pull_request,
                 base_ref=repository.default_branch or "main",
-                reason="native_merge",
+                reason="github_stack_merge",
             )
     if operation.merge_method == "merge":
         repository.apply_merge_commit(candidates)
@@ -1508,7 +1508,7 @@ def _validate_stack_members(
         )
     ):
         raise HTTPException(status_code=422, detail="Pull request bases do not form a chain.")
-    for number, existing in _native_stacks(repository).items():
+    for number, existing in _github_stacks(repository).items():
         if number != allowed_stack and not set(existing).isdisjoint(admitted_members):
             raise HTTPException(
                 status_code=422, detail="Pull request already belongs to a stack."

--- a/tests/support/submit_property_harness.py
+++ b/tests/support/submit_property_harness.py
@@ -54,7 +54,7 @@ class SubmittedBaseline:
     submitted_baseline: StoredBaseline
 
 
-def _dissolve_native_stacks(
+def _dissolve_github_stacks(
     *,
     fake_repo: FakeGithubRepository,
     stack_numbers: tuple[int, ...],
@@ -62,7 +62,7 @@ def _dissolve_native_stacks(
     """Model explicit `gh stack unstack` actions chosen by the scenario."""
 
     for stack_number in stack_numbers:
-        fake_repo.native_stacks.pop(stack_number, None)
+        fake_repo.github_stacks.pop(stack_number, None)
 
 
 def replay_successful_stack_edit_scenario(
@@ -79,7 +79,7 @@ def replay_successful_stack_edit_scenario(
 
     assert submit(None) == 0
     discard_output()
-    initial_stack_numbers = tuple(fake_repo.native_stacks)
+    initial_stack_numbers = tuple(fake_repo.github_stacks)
     baseline = _capture_submitted_baseline(repo, fake_repo, labels_to_change_ids)
     _approve_initial_pull_requests(fake_repo, baseline)
     fake_repo.pull_request_events.clear()
@@ -99,9 +99,9 @@ def replay_successful_stack_edit_scenario(
         labels=scenario.final_live_labels,
         labels_to_change_ids=labels_to_change_ids,
     )
-    _dissolve_native_stacks(
+    _dissolve_github_stacks(
         fake_repo=fake_repo,
-        stack_numbers=initial_stack_numbers,
+        stack_numbers=initial_stack_numbers if scenario.orphaned_labels else (),
     )
     assert submit(stack.head.change_id) == 0
     discard_output()
@@ -141,6 +141,7 @@ def replay_external_drift_scenario(
 
     assert run_cli(("submit",)) == 0
     discard_output()
+    initial_stack_numbers = tuple(fake_repo.github_stacks)
     baseline = _capture_submitted_baseline(repo, fake_repo, labels_to_change_ids)
     _approve_initial_pull_requests(fake_repo, baseline)
 
@@ -153,6 +154,11 @@ def replay_external_drift_scenario(
             operation=operation,
         )
     assert tuple(live_labels) == scenario.final_live_labels
+    if scenario.orphaned_labels:
+        _dissolve_github_stacks(
+            fake_repo=fake_repo,
+            stack_numbers=initial_stack_numbers,
+        )
 
     submit_revset = labels_to_change_ids[scenario.final_live_labels[-1]]
     for drift in scenario.drifts:
@@ -370,12 +376,12 @@ def replay_stack_merge_scenario(
     labels_to_change_ids = _create_labeled_stack(repo, scenario.first_stack_labels)
     assert submit(labels_to_change_ids[scenario.first_stack_labels[-1]]) == 0
     discard_output()
-    initial_stack_numbers = set(fake_repo.native_stacks)
+    initial_stack_numbers = set(fake_repo.github_stacks)
 
     labels_to_change_ids.update(_create_labeled_stack(repo, scenario.second_stack_labels))
     assert submit(labels_to_change_ids[scenario.second_stack_labels[-1]]) == 0
     discard_output()
-    initial_stack_numbers.update(fake_repo.native_stacks)
+    initial_stack_numbers.update(fake_repo.github_stacks)
 
     baseline = _capture_submitted_baseline(repo, fake_repo, labels_to_change_ids)
     _approve_initial_pull_requests(fake_repo, baseline)
@@ -398,7 +404,7 @@ def replay_stack_merge_scenario(
         labels_to_change_ids=labels_to_change_ids,
     )
 
-    _dissolve_native_stacks(
+    _dissolve_github_stacks(
         fake_repo=fake_repo,
         stack_numbers=tuple(sorted(initial_stack_numbers)),
     )
@@ -429,12 +435,12 @@ def replay_stack_move_scenario(
     labels_to_change_ids = _create_labeled_stack(repo, scenario.first_stack_labels)
     assert submit(labels_to_change_ids[scenario.first_stack_labels[-1]]) == 0
     discard_output()
-    initial_stack_numbers = set(fake_repo.native_stacks)
+    initial_stack_numbers = set(fake_repo.github_stacks)
 
     labels_to_change_ids.update(_create_labeled_stack(repo, scenario.second_stack_labels))
     assert submit(labels_to_change_ids[scenario.second_stack_labels[-1]]) == 0
     discard_output()
-    initial_stack_numbers.update(fake_repo.native_stacks)
+    initial_stack_numbers.update(fake_repo.github_stacks)
 
     baseline = _capture_submitted_baseline(repo, fake_repo, labels_to_change_ids)
     _approve_initial_pull_requests(fake_repo, baseline)
@@ -463,7 +469,7 @@ def replay_stack_move_scenario(
             labels_to_change_ids=labels_to_change_ids,
         )
 
-    _dissolve_native_stacks(
+    _dissolve_github_stacks(
         fake_repo=fake_repo,
         stack_numbers=tuple(sorted(initial_stack_numbers)),
     )

--- a/tests/unit/test_github_models.py
+++ b/tests/unit/test_github_models.py
@@ -32,7 +32,7 @@ def test_graphql_review_decision_normalizes_known_states_and_drops_unknown() -> 
     assert unknown.review_decision is None
 
 
-def test_native_stack_splits_history_and_rejects_nonprefix_history() -> None:
+def test_github_stack_splits_history_and_rejects_nonprefix_history() -> None:
     historical = {
         "head": {"ref": "jj-stack/one", "sha": "head-one"},
         "merged_at": "2026-07-23T12:00:00Z",
@@ -56,7 +56,7 @@ def test_native_stack_splits_history_and_rejects_nonprefix_history() -> None:
         GithubStack.model_validate({"number": 7, "pull_requests": [active, historical]})
 
 
-def test_native_stack_requires_two_members_and_defaults_missing_merge_state_to_active() -> None:
+def test_github_stack_requires_two_members_and_defaults_missing_merge_state_to_active() -> None:
     """GitHub rejects one-member resources and may omit `merged_at` from valid members."""
 
     stack = GithubStack.model_validate(

--- a/tests/unit/test_github_stack_planning.py
+++ b/tests/unit/test_github_stack_planning.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from jj_stack.commands.submit.native import plan_native_stack
+from jj_stack.commands.submit.github_stack import plan_github_stack
 from jj_stack.errors import CliError, error_hint, error_message
 from jj_stack.models.github import GithubStack
 from jj_stack.ui import plain_text
@@ -70,14 +70,14 @@ def _stack(
         ),
     ),
 )
-def test_native_stack_plan_classifies_selected_membership(
+def test_github_stack_plan_classifies_selected_membership(
     desired: tuple[int | None, ...],
     observed: tuple[GithubStack, ...],
     base_updates: frozenset[int],
     expected_action: str,
     expected_stack_number: int | None,
 ) -> None:
-    plan = plan_native_stack(
+    plan = plan_github_stack(
         desired=desired,
         observed_stacks=observed,
         pull_numbers_requiring_base_update=base_updates,
@@ -118,14 +118,14 @@ def test_native_stack_plan_classifies_selected_membership(
         ),
     ),
 )
-def test_native_stack_plan_rejects_ambiguous_selected_membership(
+def test_github_stack_plan_rejects_ambiguous_selected_membership(
     desired: tuple[int, ...],
     observed: tuple[GithubStack, ...],
     message_parts: tuple[str, ...],
     hint_parts: tuple[str, ...],
 ) -> None:
     with pytest.raises(CliError) as caught:
-        plan_native_stack(
+        plan_github_stack(
             desired=desired,
             observed_stacks=observed,
             pull_numbers_requiring_base_update=frozenset(),


### PR DESCRIPTION
Drop the now-meaningless native qualifier from the surviving GitHub
stack model, including API models, sync state, docs, fakes, and tests.

Recheck live membership before submit's first dependent mutation so a
concurrent append cannot change selected review diffs. Keep property
replays aligned with explicit unstack recovery after topology edits and
make stack-plan and merge-result variants reject impossible states.