### PR TITLE
docs: simplify sync terminology

### DIFF
--- a/docs/internals/backlog.md
+++ b/docs/internals/backlog.md
@@ -23,7 +23,7 @@ current core workflow._
 Since `jj` 0.30 the `change-id` header in Git commit objects is written and imported by default
 (`git.write-change-id-header`), so change IDs survive ordinary push/fetch round trips. Live GitHub
 experiments established that both GitHub stack merges and ordinary rebase merges preserve it,
-while squash merge does not. Selected `sync` uses a preserved header to recognize the fetched
+while squash merge does not. `sync` uses a preserved header to recognize the fetched
 successor;
 otherwise it retires the old local change from exact merge-result evidence without relabeling the
 commit that reached trunk or storing an alias.
@@ -228,3 +228,23 @@ the behavior and the docs are wrong about one of the two commands owning the del
 
 Decide which command deletes the branch and make the other one's docs match. Retiring tracking
 before the branch it identifies is deleted is the ordering that produces the leak.
+
+## Rebase divergent descendant paths during `sync`
+
+_Benefit: small — it could recover more local paths automatically, but divergence is unusual and
+the simpler current rule gives it one clear repair boundary._
+
+`sync` currently stops before rebasing when a surviving change is divergent. Divergent
+versions do not necessarily share parents, so rebasing every version of a change is not generally
+one well-defined stack operation.
+
+A narrower future design could work from commit ancestry instead of change identity. When an exact
+local revision whose work is proven on fetched trunk still has divergent mutable descendants,
+`sync` could find each local path that depends on that revision and rebase the path at the first
+safe descendant onto the uniquely proven replacement. It would still leave GitHub updates blocked
+for every divergent change ID.
+
+Before implementing this, decide whether `sync` may rewrite dependent paths belonging to
+other local stacks, and specify how it avoids paths with unpublished edits, ambiguous ordering, or
+different replacement destinations. Until that broader scope has a clear contract, divergence
+should continue to stop `sync` before local mutation.

--- a/docs/internals/design.md
+++ b/docs/internals/design.md
@@ -202,7 +202,7 @@ evidence, and mutation rules.
 - **`list`** reports the repository-wide inventory of local stacks and orphaned tracked reviews.
 - **`submit`** publishes the selected stack. It is the only command that creates a PR or
   publishes a never-submitted change.
-- **`sync`** on a selected stack (called **selected `sync`** below) reconciles that stack after
+- **`sync`** reconciles the selected stack after
   reviewed work lands. It may rewrite surviving local changes, update their existing reviews, and
   retire tracking for changes whose work is on trunk. It never creates a PR.
 - **`sync --all`** performs weaker repository-wide reconciliation. It may retarget and close
@@ -390,13 +390,13 @@ swap, repository retarget, renamed head, moved branch, missing PR, or replacemen
 and names `relink` or `unstack --cleanup` followed by a fresh `submit`.
 
 Only review creation, `relink`, and `checkout` create or replace identity. `unstack --local`
-deletes it explicitly; selected `sync`, `sync --all`, and cleanup retire it from evidence.
+deletes it explicitly; `sync`, `sync --all`, and cleanup retire it from evidence.
 
 Only commands that successfully send or adopt a specific reviewed commit may replace
 `SubmittedBaseline` for the same review identity:
 
-- `submit` and selected `sync`, after a survivor's review update succeeds
-- selected `sync`, when adopting an exact surviving GitHub stack commit
+- `submit` and `sync`, after a survivor's review update succeeds
+- `sync`, when adopting an exact surviving GitHub stack commit
 - `relink`, from the observed remote target
 - `checkout`, when adopting an existing review
 
@@ -482,7 +482,7 @@ merged is not one of them, because it says nothing about the trunk this reposito
   merged, still reports the submitted head, and reports a merge-result commit that is an ancestor
   of fetched trunk. This covers squash and rebase results.
 
-Selected `sync` may use either proof. `sync --all` may use only exact submitted-commit evidence
+`sync` may use either proof. `sync --all` may use only exact submitted-commit evidence
 because a rewritten merge result is selected-stack evidence and cannot support repository-wide
 local change.
 
@@ -491,7 +491,7 @@ permits no change. Local revisions, identity, and baseline remain untouched unti
 prove the result on fetched trunk.
 
 When unmerged local changes precede the local copy of reviewed work proven on fetched trunk,
-selected `sync` stops without mutation. It names the earlier changes and the exact submitted,
+`sync` stops without mutation. It names the earlier changes and the exact submitted,
 local, and fetched-trunk commits, then gives a `jj log` command for inspecting the two histories.
 The user chooses the intended order with ordinary `jj`, with agent help if useful. Afterward they
 inspect the remaining local reviews, sync a remaining mutable reviewed head, or run cleanup when
@@ -500,7 +500,7 @@ no reviewed local copy remains.
 Here unpublished local work means a mutable revision whose commit is neither its submitted
 baseline nor an exact GitHub stack head that this run may adopt.
 
-Selected `sync` reconciles the unmerged suffix only when:
+`sync` reconciles the unmerged suffix only when:
 
 - rewriting it would not discard unpublished local work
 - the remainder is linear and conflict-free
@@ -517,7 +517,7 @@ merges. A matching full change ID on fetched trunk identifies the successor rath
 an arbitrary visible side copy. When fetched trunk has no matching change ID, `sync` retires the
 old local change without relabeling that commit or storing an alias.
 
-When a GitHub stack merge rewrites active members above the merged prefix, selected `sync` adopts
+When a GitHub stack merge rewrites active members above the merged prefix, `sync` adopts
 the exact commits GitHub reports rather than replaying equivalent diffs. It accepts those heads
 and bases only while a merged tracked member of the same GitHub stack proves the transition.
 
@@ -534,7 +534,7 @@ An active unselected member, two active GitHub stacks in one selection, or membe
 changes during the command fails before branch or PR mutation. The diagnostic names the exact
 `gh stack unstack <number>` command when dissolution can unblock the operation.
 
-`submit`, `merge`, selected `sync`, and `unstack` use this rule. Cleanup instead checks each
+`submit`, `merge`, `sync`, and `unstack` use this rule. Cleanup instead checks each
 candidate and never deletes a branch needed by an active GitHub stack member.
 
 Changing the base of an active GitHub stack member requires dissolving that GitHub stack first
@@ -581,7 +581,7 @@ A pair is eligible only when:
 - no active member of a GitHub stack still needs the branch
 
 Local descendants do not substitute for the open-PR base check. Descendant visibility is evidence
-for selected `sync`, not deletion of a GitHub branch.
+for `sync`, not deletion of a GitHub branch.
 
 Identity and baseline retire only after artifact cleanup succeeds. A tracking record or PR that
 cannot be inspected is skipped. Once mutation starts, a failure stops cleanup and leaves later
@@ -614,7 +614,7 @@ even if a PR happens to use the branch name that change would generate.
 
 Inspection tolerates history exposed by fetch rather than immediately declaring the stack broken.
 `view` walks past immutable or divergent side copies of merged changes. A merged PR still in the
-local stack becomes a `cleanup needed` row naming the selected `sync`. Only when no supported
+local stack becomes a `cleanup needed` row naming `sync`. Only when no supported
 linear walk remains does `view` stop with a targeted diagnostic.
 
 A per-change lookup failure marks only that row unresolved and produces an incomplete report. A

--- a/docs/internals/distributed-state.md
+++ b/docs/internals/distributed-state.md
@@ -14,7 +14,7 @@ have defined behavior but no dedicated current scenario.
 
 1. **Local `jj` view** — the commit DAG, change visibility/mutability, ordinary local bookmarks,
    and fetched non-review remote observations. Moved by the user's `jj` commands (rebase, squash,
-   abandon, new, describe), by ordinary fetch, and by selected `sync`. Managed review branches
+   abandon, new, describe), by ordinary fetch, and by `sync`. Managed review branches
    are deliberately absent from this durable local view.
 2. **Remote Git refs** — the branch namespace of the GitHub repository. Moved by
    `jj-stack` atomic leased pushes, by anyone else's pushes (a teammate merging to `main`, an

--- a/docs/internals/implementation-strategy.md
+++ b/docs/internals/implementation-strategy.md
@@ -324,11 +324,11 @@ machine:
 - `review/github_stack_sync.py` validates historical stack members and survivor transitions
 - `commands/_github_stack_safety.py` owns the one stack membership decision:
   `selected_github_stack` resolves the single resource a selected review set belongs to and
-  requires every active member of it to be selected. `submit`, `merge`, selected `sync`,
+  requires every active member of it to be selected. `submit`, `merge`, `sync`,
   `unstack`, and cleanup call it and derive their own consequence from the resource it returns;
   none of them repeats the decision
 
-Selected stack sync uses the same fixed temporary attachment as checkout for one additional
+`sync` uses the same fixed temporary attachment as checkout for one additional
 purpose: after a stack merge rewrites the active suffix, it validates every active raw Git commit
 and parent, reobserves the whole branch set, then imports the exact top into jj. It rebases only
 trailing local descendants, abandons the replaced local active copies, and advances every adopted
@@ -376,7 +376,7 @@ and rereads the PR, its unique head claim, open base-ref dependents, remote ref,
 membership, and tracking records at their mutation boundaries. Selected cleanup processes the
 observed stack head-to-base. A dry run may omit only dependents that an earlier selected action
 would close; actual cleanup never omits a live dependent. Local jj descendants remain
-selected-sync evidence, not cleanup evidence. Shared code supplies observation and artifact
+`sync` evidence, not cleanup evidence. Shared code supplies observation and artifact
 mutation without a second set of eligibility rules.
 
 ## Data model

--- a/docs/internals/property-testing.md
+++ b/docs/internals/property-testing.md
@@ -174,7 +174,7 @@ repository-wide sync eligibility.
 
 The stack-merge tests assert both final Git and PR state and the significant API events. A
 terminal stack-merge failure changes nothing. A successful partial request may change survivor
-heads and bases, but `merge` does not rewrite local history; selected `sync` validates and
+heads and bases, but `merge` does not rewrite local history; `sync` validates and
 converges that remote
 transition. These are bounded command contracts, not generated merge property families or a
 durable recovery state machine.

--- a/src/jj_stack/review/path.py
+++ b/src/jj_stack/review/path.py
@@ -196,7 +196,7 @@ def _select_revision(observation: SelectedPathObservation) -> LocalRevision:
             raise AmbiguousSelectionError("The selector resolved to more than one revision.")
         if off_trunk:
             # A stack merge side parent is immutable to jj but remains outside
-            # the fetched trunk's first-parent path until selected sync retires it.
+            # the fetched trunk's first-parent path until sync retires it.
             return off_trunk[0]
         raise CliError("The selected change has no mutable local copy.")
 


### PR DESCRIPTION
Call the ordinary command sync because it is the default operation. Reserve
the qualified name for sync --all, and record the deferred divergent-path
recovery idea without introducing a second name for sync.