### PR TITLE
selection: recover divergent short change IDs

### DIFF
--- a/docs/daily-workflow.md
+++ b/docs/daily-workflow.md
@@ -160,10 +160,10 @@ jj-stack view --pull-request 7
 
 (You can use `-p` as an alias for `--pull-request`.)
 
-A full change ID and a linked PR continue to select the mutable local copy after you fetch an
-ordinary GitHub rebase merge. If two mutable copies of that change are visible, `jj-stack` stops;
-use `jj log -r 'change_id(<change-id>)'` to inspect them and choose or reconcile the copy you
-want.
+A change ID, including a short prefix, and a linked PR continue to select the mutable local copy
+after you fetch an ordinary GitHub rebase merge. If two mutable copies of that change are
+visible, `jj-stack` stops; use `jj log -r 'change_id(<change-id>)'` to inspect them and choose or
+reconcile the copy you want.
 
 If you want to inspect several stacks in one run, pass several selectors in
 the order you want them shown:

--- a/docs/internals/design.md
+++ b/docs/internals/design.md
@@ -94,12 +94,13 @@ descendants are out of scope unless the command explicitly selects them.
 A rebase merge preserves `jj`'s change ID, so once the result is fetched, the commit on
 trunk and the superseded local commit are two visible copies of one change ID: the local copy is
 divergent and the trunk copy is immutable. Both are recovery context, not review changes to
-publish. A full change ID or linked pull request selects that unique mutable local copy. If two
-mutable copies match, selection stops rather than choosing between them. If every matching copy
-is on fetched trunk's first-parent path, logical selection stops instead of turning the sole
-immutable trunk result into an empty local stack; an explicit revision expression can still
-select a commit on trunk. The sole immutable reviewed side parent from a stack merge is outside
-that first-parent path and remains selectable until `sync`.
+publish. A change ID, including a short prefix that identifies one logical change, or a linked
+pull request selects that unique mutable local copy. If two mutable copies match, selection stops
+rather than choosing between them. If every matching copy is on fetched trunk's first-parent
+path, logical selection stops instead of turning the sole immutable trunk result into an empty
+local stack; an explicit revision expression can still select a commit on trunk. The sole
+immutable reviewed side parent from a stack merge is outside that first-parent path and remains
+selectable until `sync`.
 
 ### Tracking
 
@@ -349,11 +350,11 @@ supported.
 Stack lifecycle commands default to `@` when the working-copy change has a nonblank description
 and contents, and to `@-` otherwise. Explicit empty or undescribed working-copy selections fail.
 `view` may accept several selectors. A revision expression selects the exact revision it
-resolves to. A full change ID or linked pull request instead selects the unique mutable copy
-outside fetched trunk's first-parent path, so fetching an ordinary rebase result does not hide
-the local path. As defined for local review stacks, the sole immutable reviewed side parent from
-a stack merge remains selectable outside that path until `sync`. `relink` requires both the
-change and PR.
+resolves to. A change ID, including a prefix that identifies one logical change, or a linked pull
+request instead selects the unique mutable copy outside fetched trunk's first-parent path, so
+fetching an ordinary rebase result does not hide the local path. As defined for local review
+stacks, the sole immutable reviewed side parent from a stack merge remains selectable outside
+that path until `sync`. `relink` requires both the change and PR.
 
 Three modes deliberately reach beyond one selected stack:
 

--- a/docs/internals/implementation-strategy.md
+++ b/docs/internals/implementation-strategy.md
@@ -227,12 +227,12 @@ This is where most correctness lives.
 
 Selected path planning has a smaller pure boundary in `review/path.py`. The selected adapter
 observes selector copies, the ordinary first-parent chain, fetched-trunk membership, and tracking
-annotations in one bounded `jj` query. For a full change ID or linked pull request, the pure
-projection prefers the unique mutable local copy outside fetched trunk's first-parent path and
-stops when matches remain only on that path. A sole immutable reviewed side parent from a stack
-merge remains outside the path and selectable until `sync`. The projection returns one
-parent-connected `LocalStack`. Tracking annotates that path and cannot create or reorder it.
-Command-owned GitHub identity, merge evidence, and mutation policy stay outside the projection.
+annotations in one bounded `jj` query. For a change ID or linked pull request, the pure projection
+prefers the unique mutable local copy outside fetched trunk's first-parent path and stops when
+matches remain only on that path. A sole immutable reviewed side parent from a stack merge
+remains outside the path and selectable until `sync`. The projection returns one parent-connected
+`LocalStack`. Tracking annotates that path and cannot create or reorder it. Command-owned GitHub
+identity, merge evidence, and mutation policy stay outside the projection.
 
 The same module folds a bounded repository observation into ordinary maximal linear paths.
 `review/repository.py` collects visible off-trunk candidates, their base parents, fetched-trunk

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,8 +26,8 @@ jj log -r 'change_id(<change-id>)'
 ```
 
 One mutable copy beside an immutable copy on fetched trunk is different: that is the ordinary
-result of fetching a GitHub rebase merge, and the full change ID or linked PR selects the mutable
-local copy.
+result of fetching a GitHub rebase merge, and a change ID, including a short prefix, or a linked
+PR selects the mutable local copy.
 
 ## A command says a PR is claimed by multiple tracked records
 

--- a/src/jj_stack/cli.py
+++ b/src/jj_stack/cli.py
@@ -201,7 +201,7 @@ def build_parser() -> ArgumentParser:
         description_text=submit_command.__doc__ or "",
         handler=_forward_handler(submit_command.submit, open_="open"),
         revset_help=(
-            t"Revision or full change ID to submit; defaults to {ui.revset('@')} when the "
+            t"Revision or change ID to submit; defaults to {ui.revset('@')} when the "
             t"working-copy change is described and nonempty, otherwise {ui.revset('@-')}"
         ),
     )
@@ -297,7 +297,7 @@ def build_parser() -> ArgumentParser:
             selectors=lambda args: args.view_selectors,
         ),
         revset_help=(
-            "Revsets or full change IDs to inspect; can be mixed with --pull-request selectors; "
+            "Revsets or change IDs to inspect; can be mixed with --pull-request selectors; "
             "defaults to the current stack"
         ),
         revset_nargs="*",
@@ -349,7 +349,7 @@ def build_parser() -> ArgumentParser:
         description_text=merge_command.__doc__ or "",
         handler=_forward_handler(merge_command.merge),
         revset_help=(
-            t"Revision or full change ID to merge; defaults to {ui.revset('@')} when the "
+            t"Revision or change ID to merge; defaults to {ui.revset('@')} when the "
             t"working-copy change is described and nonempty, otherwise {ui.revset('@-')}; "
             t"cannot be combined with {ui.cmd('--pull-request')}"
         ),
@@ -384,7 +384,7 @@ def build_parser() -> ArgumentParser:
         description_text=unstack_command.__doc__ or "",
         handler=_forward_handler(unstack_command.unstack),
         revset_help=(
-            t"Revision or full change ID to unstack; defaults to {ui.revset('@')} when the "
+            t"Revision or change ID to unstack; defaults to {ui.revset('@')} when the "
             t"working-copy change is described and nonempty, otherwise {ui.revset('@-')}; "
             t"cannot be combined with {ui.cmd('--pull-request')}"
         ),
@@ -441,7 +441,7 @@ def build_parser() -> ArgumentParser:
         description_text=sync_command.__doc__ or "",
         handler=_forward_handler(sync_command.sync, all_="all"),
         revset_help=(
-            t"Revision or full change ID to sync; defaults to {ui.revset('@')} when the "
+            t"Revision or change ID to sync; defaults to {ui.revset('@')} when the "
             t"working-copy change is described and nonempty, otherwise {ui.revset('@-')}"
         ),
     )
@@ -898,7 +898,7 @@ def _add_relink_parser(
         parser,
         "revset",
         metavar="REVSET",
-        help="Revision or full change ID to reassociate with the pull request",
+        help="Revision or change ID to reassociate with the pull request",
     )
     return parser
 

--- a/src/jj_stack/jj/client.py
+++ b/src/jj_stack/jj/client.py
@@ -1219,6 +1219,14 @@ def _revset_resolution_error(revset: str, error: JjCommandError) -> CliError | N
     return None
 
 
+def divergent_change_id_from_error(error: JjCommandError) -> str | None:
+    """Return the short change ID that made a bare revset symbol divergent."""
+
+    first_line = _unwrap_command_error_message(str(error)).splitlines()[0].strip()
+    match = re.fullmatch(r"Error: Change ID `([k-z]+)` is divergent", first_line)
+    return match.group(1) if match is not None else None
+
+
 def _parse_revision_line(line: str) -> LocalRevision:
     parts = line.split("\t")
     if len(parts) != _EXPECTED_FIELD_COUNT:

--- a/src/jj_stack/review/selected.py
+++ b/src/jj_stack/review/selected.py
@@ -6,7 +6,12 @@ import json
 
 import jj_stack.ui as ui
 from jj_stack.errors import CliError
-from jj_stack.jj.client import JjClient, UnsupportedStackError
+from jj_stack.jj.client import (
+    JjClient,
+    JjCommandError,
+    UnsupportedStackError,
+    divergent_change_id_from_error,
+)
 from jj_stack.models.review_state import ReviewState
 from jj_stack.models.stack import LocalRevision
 from jj_stack.review.path import (
@@ -37,11 +42,22 @@ def select_review_path(
         selected_revset = revset
         select_mutable_copy = False
 
-    rows = _observe_path_rows(
-        jj_client=jj_client,
-        selector=selector,
-        selected_revset=revset,
-    )
+    try:
+        rows = _observe_path_rows(
+            jj_client=jj_client,
+            selector=selector,
+            selected_revset=revset,
+        )
+    except JjCommandError as error:
+        if revset is None or divergent_change_id_from_error(error) != revset:
+            raise
+        selector = _change_id_revset(revset)
+        select_mutable_copy = True
+        rows = _observe_path_rows(
+            jj_client=jj_client,
+            selector=selector,
+            selected_revset=revset,
+        )
     path = _project_rows(
         rows=rows,
         selected_revset=selected_revset,

--- a/tests/integration/test_sync_command.py
+++ b/tests/integration/test_sync_command.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from copy import deepcopy
 from pathlib import Path
 
@@ -118,7 +119,7 @@ def test_sync_recovers_a_clean_single_review_rebase_merge(
     assert reviewed.change_id not in state_store.load().review_identities
 
 
-def test_sync_converges_the_local_stack_after_merge(
+def test_merge_prints_a_short_sync_target_that_converges_the_local_stack(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -129,15 +130,19 @@ def test_sync_converges_the_local_stack_after_merge(
     stack = selected_stack(repo)
     top_change_id = stack.revisions[1].change_id
     top_commit_id = stack.revisions[1].commit_id
+    abbreviated_change_id = top_change_id[:8]
 
-    merge_exit_code = run_main(repo, config_path, "merge")
-    capsys.readouterr()
+    merge_exit_code = run_main(repo, config_path, "merge", abbreviated_change_id)
+    merged = capsys.readouterr()
     assert merge_exit_code == 0
     assert fake_repo.pull_requests[1].merged_at is not None
     assert fake_repo.pull_requests[2].state == "open"
     assert JjClient(repo).resolve_revision(top_change_id).commit_id == top_commit_id
+    match = re.search(r"jj-stack sync\s+([k-z]+)", merged.out)
+    assert match is not None, merged.out
+    assert match.group(1) == abbreviated_change_id
 
-    sync_exit_code = run_main(repo, config_path, "sync", top_change_id)
+    sync_exit_code = run_main(repo, config_path, "sync", match.group(1))
     captured = capsys.readouterr()
 
     assert sync_exit_code == 0, (captured.out, captured.err)


### PR DESCRIPTION
Keep the short change ID printed by merge usable after sync fetches a
rebase merge and jj exposes trunk and local copies as divergent. Retry
that exact selector as a logical change ID while preserving ambiguity
checks for multiple mutable copies.