### PR TITLE
sync: retire stacked rewriting merges locally

### DIFF
--- a/complexity-budget.toml
+++ b/complexity-budget.toml
@@ -13,7 +13,7 @@ governed_c901 = 0
 
 [pytest]
 fixed_property = 8
-merge_recovery = 52
+merge_recovery = 54
 
 [labels]
 production = "Production"

--- a/docs/internals/implementation-strategy.md
+++ b/docs/internals/implementation-strategy.md
@@ -458,7 +458,7 @@ Implemented local coverage includes:
 - local integration tests against the fake GitHub server and a real backing Git repo
 - five fixed generated/property cases that replay the integration harness in the default suite
 - focused merge and recovery cases, including atomic stack-merge failure, partial survivor
-  rewrites, terminal retry, and single-PR merge topology
+  rewrites, terminal retry, single-PR merge topology, and multi-PR rewriting-merge convergence
 
 Local tests are the default.
 

--- a/src/jj_stack/commands/merge/preconditions.py
+++ b/src/jj_stack/commands/merge/preconditions.py
@@ -116,7 +116,7 @@ def _local_precondition_error(
     """Explain why the local change and its review branch do not match the plan."""
 
     identity = observed.identity
-    local = observed.local_revision
+    local_revisions = observed.local_revisions
     label = planned.change_id
     if (
         identity != planned.identity
@@ -124,12 +124,13 @@ def _local_precondition_error(
         or identity.repository_key != expected_repository.repository_key
     ):
         return f"saved PR tracking for {label} changed"
-    if local is None:
+    if not local_revisions:
         return f"{label} is no longer visible locally"
     # Stack discovery normally rejects a divergent change first; this covers one that diverged
     # after the plan was built.
-    if local.divergent:
+    if len(local_revisions) > 1 or local_revisions[0].divergent:
         return f"{label} has more than one visible revision"
+    local = local_revisions[0]
     # Conflicts come before the commit comparison: a rebase that conflicts also changes the
     # commit, and resolving is what has to happen first either way.
     if local.conflict:

--- a/src/jj_stack/review/finish.py
+++ b/src/jj_stack/review/finish.py
@@ -269,6 +269,8 @@ async def _fresh_retirement_blocker(
         for revision in local_revisions
     ):
         return t"{ui.change_id(candidate.change_id)} has unpublished local edits"
+    if any(not revision.immutable for revision in local_revisions):
+        return t"{ui.change_id(candidate.change_id)} still has an editable local revision"
     observation, reason = await observe_tracked_review(candidate, finish)
     if reason is not None or observation is None:
         return reason

--- a/src/jj_stack/review/github_stack_sync.py
+++ b/src/jj_stack/review/github_stack_sync.py
@@ -109,8 +109,7 @@ def _changed_review(observed: review_observation.ReviewObservation) -> bool:
         pull_request.normalize_state().state == "merged"
         or pull_request.head.sha != baseline.commit_id
         or observed.remote_review_target != baseline.commit_id
-        or observed.local_revision is not None
-        and observed.local_revision.immutable
+        or any(revision.immutable for revision in observed.local_revisions)
     )
 
 
@@ -172,6 +171,18 @@ def build_selected_github_stack_sync(
             observation=observation,
         )
         if member.is_historical:
+            selected_revision = selected_by_change_id.get(candidate.change_id)
+            editable = tuple(
+                revision
+                for revision in observation.reviews[candidate.change_id].local_revisions
+                if not revision.immutable
+            )
+            if selected_revision is None and len(editable) > 1:
+                raise CliError(
+                    t"Historical stack member {ui.change_id(candidate.change_id)} has more "
+                    t"than one editable local revision.",
+                    hint=t"Resolve the divergent change with {ui.cmd('jj')}, then rerun sync.",
+                )
             historical.append(
                 _historical_review(
                     candidate=candidate,
@@ -179,7 +190,7 @@ def build_selected_github_stack_sync(
                     member=member,
                     pull_request=pull_request,
                     repository=repository,
-                    revision=observation.reviews[candidate.change_id].local_revision,
+                    revision=selected_revision or (editable[0] if editable else None),
                     trunk_commit_id=trunk_commit_id,
                 )
             )

--- a/src/jj_stack/review/observation.py
+++ b/src/jj_stack/review/observation.py
@@ -25,7 +25,7 @@ class ReviewObservation:
     baseline: SubmittedBaseline | None
     head_pull_requests: tuple[GithubPullRequest, ...]
     identity: ReviewIdentity | None
-    local_revision: LocalRevision | None
+    local_revisions: tuple[LocalRevision, ...]
     pull_request: GithubPullRequest | None
     remote_review_target: str | None
 
@@ -119,7 +119,7 @@ async def observe_reviews(
                 by_head.get(identity.head_ref, ()) if identity is not None else ()
             ),
             identity=identity,
-            local_revision=(matches[0] if len(matches) == 1 else None),
+            local_revisions=matches,
             pull_request=(numbered.get(identity.pr_number) if identity is not None else None),
             remote_review_target=(
                 remote_targets.get(identity.head_ref) if identity is not None else None

--- a/tests/integration/test_merge_command.py
+++ b/tests/integration/test_merge_command.py
@@ -237,6 +237,45 @@ def test_stack_merge_commit_uses_one_group_result_that_sync_can_retire(
     assert JjClient(repo).resolve_revision("@").parents == (merge_commit,)
 
 
+@pytest.mark.parametrize("merge_method", ("rebase", "squash"))
+def test_stack_rewriting_merge_sync_retires_pre_merge_copies(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+    merge_method: str,
+) -> None:
+    repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
+    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
+    fake_repo.allow_rebase_merge = True
+    fake_repo.github_stacks = {7: (1, 2)}
+    state_store = ReviewStateStore.for_repo(repo)
+    stack = selected_stack(repo)
+
+    merge_exit_code = run_main(repo, config_path, "merge", "--method", merge_method)
+    merged = capsys.readouterr()
+    final_trunk = fake_repo.pull_requests[2].merge_commit_sha
+
+    assert merge_exit_code == 0, (merged.out, merged.err)
+    assert final_trunk == read_remote_ref(fake_repo.git_dir, "main")
+
+    sync_exit_code = run_main(repo, config_path, "sync", stack.head.change_id)
+    synced = capsys.readouterr()
+
+    assert sync_exit_code == 0, (synced.out, synced.err)
+    assert state_store.load().review_identities == {}
+    assert JjClient(repo).resolve_revision("@").parents == (final_trunk,)
+    copies = JjClient(repo).query_revisions_by_change_ids(
+        tuple(revision.change_id for revision in stack.revisions)
+    )
+    if merge_method == "rebase":
+        assert all(
+            len(revisions) == 1 and revisions[0].immutable and not revisions[0].divergent
+            for revisions in copies.values()
+        )
+    else:
+        assert all(not revisions for revisions in copies.values())
+
+
 def test_stack_merge_terminal_failure_is_atomic(
     tmp_path: Path,
     monkeypatch,

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -180,7 +180,7 @@ def _observation(
                 baseline=_BASELINE,
                 head_pull_requests=(pull_request,),
                 identity=identity,
-                local_revision=None,
+                local_revisions=(),
                 pull_request=pull_request,
                 remote_review_target=remote_target,
             )


### PR DESCRIPTION
Preserve every visible local revision in review observations so stack
convergence can distinguish the pre-merge revision from a rewritten
successor on trunk. This lets sync rebase descendants and abandon the
obsolete local stack before removing its tracking.

Keep tracking when an editable local revision unexpectedly remains, and
cover full multi-PR rebase and squash merge convergence.