### PR TITLE
view: show complete stacks for identity selectors

### DIFF
--- a/docs/daily-workflow.md
+++ b/docs/daily-workflow.md
@@ -166,10 +166,12 @@ jj-stack view --pull-request 7
 
 (You can use `-p` as an alias for `--pull-request`.)
 
-A change ID, including a short prefix, and a linked PR continue to select the mutable local copy
-after you fetch an ordinary GitHub rebase merge. If two mutable copies of that change are
-visible, `jj-stack` stops; use `jj log -r 'change_id(<change-id>)'` to inspect them and choose or
-reconcile the copy you want.
+A change ID, including a short prefix, and a linked PR show the complete local stack containing
+that change. An arbitrary revset instead selects the exact revision at which the displayed stack
+ends. After you fetch an ordinary GitHub rebase merge, a change ID or PR selects the remaining
+local revision instead of the landed commit. If two local revisions or several containing paths
+are visible, `jj-stack` stops; use `jj log -r 'change_id(<change-id>)'` to inspect them and choose
+or reconcile the path you want.
 
 If you want to inspect several stacks in one run, pass several selectors in
 the order you want them shown:
@@ -405,11 +407,9 @@ jj-stack unstack --local <head-change-id>
 
 If `jj-stack list` says another tracked stack changed since its last submit, either run
 `jj-stack submit <head-change-id>` to refresh the PR branches or run
-`jj-stack view <head-change-id>` to inspect first. `view` only emits this warning for another
-stack when its local path shares a change with the stack you are inspecting, such as two paths
-created by splitting above a reviewed change. A stack that only shares trunk stays silent.
-`view` also calls out which tracked changes no longer match their last submitted commits, and
-whether `jj-stack sync <head-change-id>` is needed first.
+`jj-stack view <head-change-id>` to inspect first. `view` also calls out which tracked changes in
+the selected stack no longer match their last submitted commits, and whether
+`jj-stack sync <head-change-id>` is needed first.
 
 ## Short version
 

--- a/docs/internals/design.md
+++ b/docs/internals/design.md
@@ -360,12 +360,18 @@ supported.
 
 Stack lifecycle commands default to `@` when the working-copy change has a nonblank description
 and contents, and to `@-` otherwise. Explicit empty or undescribed working-copy selections fail.
-`view` may accept several selectors. A revision expression selects the exact revision it
-resolves to. A change ID, including a prefix that identifies one logical change, or a linked pull
-request instead selects the unique mutable copy outside fetched trunk's first-parent path, so
-fetching an ordinary rebase result does not hide the local path. As defined for local review
-stacks, the sole immutable reviewed side parent from a stack merge remains selectable outside
-that path until `sync`. `relink` requires both the change and PR.
+`view` may accept several selectors. An arbitrary revision expression selects the exact revision
+it resolves to as the stack head. A bare change ID, including a prefix that identifies one
+logical change, or a linked pull request identifies the complete local stack containing that
+change. The containing stack ends at the unique visible head descended from the selected change;
+several such heads are ambiguous and selection fails closed.
+
+Logical selection first selects the unique mutable copy outside fetched trunk's first-parent
+path, so fetching an ordinary rebase result does not hide the local path. As defined for local
+review stacks, the sole immutable reviewed side parent from a stack merge remains selectable
+outside that path until `sync`. Other commands retain their action-specific selection boundary;
+for example, `merge --pull-request` merges only through the selected PR. `relink` requires both
+the change and PR.
 
 Three modes deliberately reach beyond one selected stack:
 
@@ -717,8 +723,7 @@ wait for their own explicit commands.
 
 Stacks not yet resubmitted may still show old overview comments. That is expected:
 `submit` does not mutate stacks outside its selection. `list` identifies stale reviews across the
-repository. `view` does so only for another path that shares an observed revision with the
-selected path. Both compare each baseline with the current change and name the stack to refresh.
+repository by comparing each baseline with the current change and naming the stack to refresh.
 Close orphaned PRs on GitHub, then remove their leftovers with
 `cleanup --pull-request <pr>`.
 

--- a/docs/mental-model.md
+++ b/docs/mental-model.md
@@ -66,10 +66,13 @@ merge, GitHub may keep them in that group as history, so the remaining PR can st
 existing group. The local DAG decides which changes belong together; the grouping on GitHub
 follows from it.
 
-Commands follow the selected change's parent chain. A reviewed change can be a common ancestor of
-several local paths; operating on one path leaves its siblings alone. The only extra constraint
-comes from an existing GitHub stack: if GitHub groups active PRs into one unit for an operation,
-`jj-stack` stops rather than changing only an unsafe subset of that group.
+Most commands follow the selected change's parent chain. `view` treats a bare change ID or linked
+PR as the identity of a stack member and shows the complete containing stack instead. If the
+local DAG has several possible containing heads, the identity is ambiguous and `view` stops.
+An arbitrary revset still names an exact stack head.
+
+The existing GitHub stack remains a safety boundary: if GitHub groups active PRs into one unit
+for an operation, `jj-stack` stops rather than changing only an unsafe subset of that group.
 
 ## Practical rule
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -184,11 +184,9 @@ but it did not remove the shared change or its tracking because the other path s
 Run each `jj-stack sync <head-change-id>` command printed by the message. After every dependent
 path has moved to trunk, the last run can remove the old local change and its tracking.
 
-## `list` or `view` says another stack changed since its last submit
+## `list` says another stack changed since its last submit
 
 `list` checks every stack known to local tracking. It does not discover GitHub-only stacks.
-`view` checks another locally tracked stack only when that stack is built on top of a change in
-the stack you are inspecting.
 
 Possible causes:
 

--- a/src/jj_stack/cli.py
+++ b/src/jj_stack/cli.py
@@ -296,8 +296,8 @@ def build_parser() -> ArgumentParser:
             selectors=lambda args: args.view_selectors,
         ),
         revset_help=(
-            "Revsets or change IDs to inspect; can be mixed with --pull-request selectors; "
-            "defaults to the current stack"
+            "Revsets select an exact stack head; change IDs select their complete containing "
+            "stack; can be mixed with --pull-request selectors; defaults to the current stack"
         ),
         revset_nargs="*",
     )
@@ -306,7 +306,10 @@ def build_parser() -> ArgumentParser:
         *_PULL_REQUEST_OPTION_STRINGS,
         metavar="PR",
         action="append",
-        help="Inspect the stack for this PR number or URL; repeat to inspect several stacks",
+        help=(
+            "Inspect the complete stack containing this PR number or URL; repeat to inspect "
+            "several stacks"
+        ),
     )
     view_parser.add_argument(
         "--json",

--- a/src/jj_stack/commands/view.py
+++ b/src/jj_stack/commands/view.py
@@ -12,9 +12,9 @@ Common examples:
 - `jj-stack view` inspects the stack ending at `@` when the working-copy change is described and
   nonempty, otherwise `@-`.
 
-- `jj-stack view --pull-request 123` finds the local stack for one linked PR.
+- `jj-stack view --pull-request 123` finds the complete local stack containing one linked PR.
 
-- `jj-stack view <head-change-id>` selects another stack explicitly.
+- `jj-stack view <change-id>` finds the complete local stack containing that change.
 """
 
 from __future__ import annotations
@@ -29,7 +29,6 @@ import jj_stack.console as console
 import jj_stack.ui as ui
 from jj_stack.bootstrap import CommandContext, bootstrap_context
 from jj_stack.commands._json_status import review_change_json
-from jj_stack.commands._stale_stacks import emit_stale_stacks_advisory
 from jj_stack.errors import EXIT_INCOMPLETE, CliError, error_message
 from jj_stack.formatting import (
     RenderableRevision,
@@ -43,9 +42,12 @@ from jj_stack.github.error_messages import (
     remote_unavailable_message,
 )
 from jj_stack.jj.cli_args import JjCliArgs
-from jj_stack.jj.client import UnsupportedStackError
-from jj_stack.models.review_state import ReviewIdentity, ReviewState
-from jj_stack.models.stack import LocalStack
+from jj_stack.jj.client import (
+    JjCommandError,
+    UnsupportedStackError,
+    divergent_change_id_from_error,
+)
+from jj_stack.models.review_state import ReviewIdentity
 from jj_stack.review.branches import (
     is_review_branch,
     review_branch_glob,
@@ -54,7 +56,7 @@ from jj_stack.review.change_status import (
     ReviewChangeStatus,
     classify_review_status_revision,
 )
-from jj_stack.review.repository import observe_repository_paths
+from jj_stack.review.selected import is_change_id_prefix
 from jj_stack.review.selection import (
     resolve_linked_change_for_pull_request,
     resolve_selected_revset,
@@ -90,6 +92,7 @@ class ViewSelector:
 class _ResolvedViewSelector:
     note: ui.Message | None
     revset: str | None
+    containing_change_id: str | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -152,19 +155,12 @@ def _run_status(
             prepared_status=prepared_status,
             verbose=verbose,
         )
-        _emit_connected_stale_stacks_advisory(
-            context=context,
-            rendered_stacks=(prepared_status.prepared.stack,),
-            state=prepared_status.prepared.state,
-        )
         return exit_code
 
     exit_code = 0
     multi_selector = len(selectors) > 1
     rendered_stack_keys: set[tuple[str, ...]] = set()
-    rendered_stacks: list[LocalStack] = []
     json_stacks: list[dict[str, object]] = []
-    state: ReviewState | None = None
     printed_blocks = 0
     for selector in selectors:
         try:
@@ -173,6 +169,7 @@ def _run_status(
                 selector=selector,
             )
             prepared_status = _prepare_status_with_spinner(
+                containing_change_id=resolved_selector.containing_change_id,
                 context=context,
                 revset=resolved_selector.revset,
             )
@@ -202,9 +199,6 @@ def _run_status(
         if stack_key in rendered_stack_keys:
             continue
         rendered_stack_keys.add(stack_key)
-        rendered_stacks.append(prepared_status.prepared.stack)
-        state = prepared_status.prepared.state
-
         if as_json:
             rendered, incomplete = _json_prepared_status(
                 prepared_status=prepared_status,
@@ -238,58 +232,7 @@ def _run_status(
             )
         )
         return exit_code
-    if state is not None:
-        _emit_connected_stale_stacks_advisory(
-            context=context,
-            rendered_stacks=tuple(rendered_stacks),
-            state=state,
-        )
     return exit_code
-
-
-def _emit_connected_stale_stacks_advisory(
-    *,
-    context: CommandContext,
-    rendered_stacks: tuple[LocalStack, ...],
-    state: ReviewState,
-) -> None:
-    """Hint that connected stacks changed since their last successful submit.
-
-    This intentionally walks only descendants of the stack(s) view rendered.
-    Repo-wide stale-stack warnings belong to `list`; plain `view` should not
-    inspect or warn about unrelated review work.
-    """
-
-    if not state.review_identities:
-        return
-    selected_commit_ids = tuple(
-        revision.commit_id for stack in rendered_stacks for revision in stack.revisions
-    )
-    if not selected_commit_ids:
-        return
-    repository_paths = observe_repository_paths(
-        jj_client=context.jj_client,
-        descendant_of=selected_commit_ids,
-        state=state,
-    )
-    rendered_head_commit_ids = {stack.head.commit_id for stack in rendered_stacks}
-    rendered_change_ids = {
-        revision.change_id for stack in rendered_stacks for revision in stack.revisions
-    }
-    other_stacks = tuple(
-        path.stack
-        for path in repository_paths.paths
-        if path.stack.head.commit_id not in rendered_head_commit_ids
-        and path.tracked_change_ids - rendered_change_ids
-    )
-    if not other_stacks:
-        return
-    emit_stale_stacks_advisory(
-        stacks=other_stacks,
-        state=state,
-        single_subject="Other tracked stack",
-        plural_subject="Other tracked stacks",
-    )
 
 
 def _normalize_status_selectors(
@@ -331,27 +274,51 @@ def _resolve_status_selector(
         )
         return _ResolvedViewSelector(
             note=t"Using PR #{pull_request_number} -> {ui.revset(resolved_revset)}",
-            revset=resolved_revset,
+            revset=None,
+            containing_change_id=resolved_revset,
         )
+    resolved_revset = resolve_selected_revset(
+        command_label="view",
+        default_revset=None,
+        require_explicit=False,
+        revset=selector.value,
+    )
+    containing_change_id = _change_id_selector(
+        context=context,
+        value=resolved_revset,
+    )
     return _ResolvedViewSelector(
         note=None,
-        revset=resolve_selected_revset(
-            command_label="view",
-            default_revset=None,
-            require_explicit=False,
-            revset=selector.value,
-        ),
+        revset=None if containing_change_id is not None else resolved_revset,
+        containing_change_id=containing_change_id,
     )
+
+
+def _change_id_selector(*, context: CommandContext, value: str | None) -> str | None:
+    """Recognize a bare change ID without misclassifying a bookmark."""
+
+    if not is_change_id_prefix(value):
+        return None
+    assert value is not None
+    try:
+        revision = context.jj_client.resolve_revision(value)
+    except JjCommandError as error:
+        if divergent_change_id_from_error(error) == value:
+            return value
+        raise
+    return value if revision.change_id.startswith(value) else None
 
 
 def _prepare_status_for_revset(
     *,
+    containing_change_id: str | None = None,
     context: CommandContext,
     revset: str | None,
 ) -> PreparedStatus:
     try:
         return prepare_status(
             context=context,
+            containing_change_id=containing_change_id,
             fetch_remote_state=False,
             revset=revset,
         )
@@ -361,11 +328,13 @@ def _prepare_status_for_revset(
 
 def _prepare_status_with_spinner(
     *,
+    containing_change_id: str | None = None,
     context: CommandContext,
     revset: str | None,
 ) -> PreparedStatus:
     with console.spinner(description="Inspecting jj stack"):
         return _prepare_status_for_revset(
+            containing_change_id=containing_change_id,
             context=context,
             revset=revset,
         )

--- a/src/jj_stack/review/path.py
+++ b/src/jj_stack/review/path.py
@@ -198,7 +198,7 @@ def _select_revision(observation: SelectedPathObservation) -> LocalRevision:
             # A stack merge side parent is immutable to jj but remains outside
             # the fetched trunk's first-parent path until sync retires it.
             return off_trunk[0]
-        raise CliError("The selected change has no mutable local copy.")
+        raise CliError("This change is already on trunk, so it is not part of a local stack.")
 
     if len(candidates) != 1:
         raise AmbiguousSelectionError("The selector resolved to more than one revision.")

--- a/src/jj_stack/review/selected.py
+++ b/src/jj_stack/review/selected.py
@@ -87,7 +87,9 @@ def select_review_path_containing_change(
     prepare_visible_review_snapshots(jj_client=jj_client, state=state)
     linked_selector = _change_id_revset(change_id)
     trunk_path = "first_ancestors(trunk())"
-    containing_heads = f"heads((({linked_selector}) ~ {trunk_path}):: ~ {trunk_path} ~ empty())"
+    nonempty_descendants = f"((({linked_selector}) ~ {trunk_path}):: ~ {trunk_path}) ~ empty()"
+    selected_empty_change = f"({linked_selector}) & empty()"
+    containing_heads = f"heads(({nonempty_descendants}) | ({selected_empty_change}))"
     rows = _observe_path_rows(
         jj_client=jj_client,
         selector=containing_heads,
@@ -262,4 +264,12 @@ def _change_id_revset(change_id: str) -> str:
 
 
 def _is_full_change_id(value: str) -> bool:
-    return len(value) == 32 and all("k" <= character <= "z" for character in value)
+    return len(value) == 32 and is_change_id_prefix(value)
+
+
+def is_change_id_prefix(value: str | None) -> bool:
+    """Return whether a bare selector has jj change-ID syntax."""
+
+    return (
+        value is not None and bool(value) and all("k" <= character <= "z" for character in value)
+    )

--- a/tests/integration/test_view_command.py
+++ b/tests/integration/test_view_command.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from jj_stack.errors import EXIT_FAILURE, EXIT_INCOMPLETE, EXIT_NO_STACK
+from jj_stack.errors import EXIT_AMBIGUOUS, EXIT_FAILURE, EXIT_INCOMPLETE, EXIT_NO_STACK
 from jj_stack.github.client import GithubClient, GithubClientError
 from jj_stack.jj.client import JjClient
 from jj_stack.state.store import ReviewStateStore, resolve_state_path
@@ -168,7 +168,7 @@ def test_view_rejects_empty_working_copy_inside_stack_from_another_workspace(
     assert "empty working-copy commits are not reviewable" in captured.err
 
 
-def test_view_can_select_a_stack_by_pull_request_number(
+def test_view_identity_selectors_show_the_complete_containing_stack(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -195,66 +195,45 @@ def test_view_can_select_a_stack_by_pull_request_number(
     assert f"Using PR #{first_pr_number} -> {first_change_id}" in captured.out
     assert "feature 1" in captured.out
     assert "PR #1" in captured.out
+    assert "feature 2" in captured.out
+    assert f"PR #{second_pr_number}" in captured.out
+
+    exit_code = run_main(repo, config_path, "view", first_change_id[:8])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "feature 1" in captured.out
+    assert f"PR #{first_pr_number}" in captured.out
+    assert "feature 2" in captured.out
+    assert f"PR #{second_pr_number}" in captured.out
+
+    exit_code = run_main(
+        repo,
+        config_path,
+        "view",
+        f'change_id("{first_change_id}")',
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "feature 1" in captured.out
+    assert f"PR #{first_pr_number}" in captured.out
+    assert "feature 2" not in captured.out
+    assert f"PR #{second_pr_number}" not in captured.out
+
+    bookmark = "zzzzzzzzzzzzzzzz"
+    run_command(["jj", "bookmark", "create", bookmark, "-r", first_change_id], repo)
+    exit_code = run_main(repo, config_path, "view", bookmark)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "feature 1" in captured.out
+    assert f"PR #{first_pr_number}" in captured.out
     assert "feature 2" not in captured.out
     assert f"PR #{second_pr_number}" not in captured.out
 
 
-def test_view_warns_only_for_connected_stack_built_on_selected_head(
-    tmp_path: Path,
-    monkeypatch,
-    capsys,
-) -> None:
-    repo, fake_repo = init_fake_github_repo(tmp_path)
-    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-
-    # Selected stack: submitted and unchanged.
-    commit_file(repo, "alpha 1", "alpha-1.txt")
-    commit_file(repo, "alpha 2", "alpha-2.txt")
-    assert run_main(repo, config_path, "submit") == 0
-    capsys.readouterr()
-    alpha_head_change_id = selected_stack(repo).head.change_id
-
-    # Connected stack built on the selected head, then advanced past its submit.
-    commit_file(repo, "connected 1", "connected-1.txt")
-    assert run_main(repo, config_path, "submit") == 0
-    capsys.readouterr()
-    connected_head_change_id = selected_stack(repo).head.change_id
-    # Rewriting the submitted change gives it a new commit ID, which is the
-    # staleness signal the advisory derives from the DAG.
-    run_command(
-        ["jj", "describe", "-r", connected_head_change_id, "-m", "connected 1 edited"],
-        repo,
-    )
-
-    # Unrelated stack forked from trunk, also advanced past its submit.
-    run_command(["jj", "new", "main"], repo)
-    commit_file(repo, "unrelated 1", "unrelated-1.txt")
-    assert run_main(repo, config_path, "submit") == 0
-    capsys.readouterr()
-    unrelated_head_change_id = selected_stack(repo).head.change_id
-    run_command(
-        ["jj", "describe", "-r", unrelated_head_change_id, "-m", "unrelated 1 edited"],
-        repo,
-    )
-
-    exit_code = run_main(repo, config_path, "view", alpha_head_change_id)
-    captured = capsys.readouterr()
-    normalized_err = " ".join(captured.err.split())
-
-    assert exit_code == 0
-    # The connected stack changed since its submit and gets an advisory.
-    assert connected_head_change_id[:8] in captured.err
-    assert "changed since its last submit" in captured.err
-    assert f"jj-stack view {connected_head_change_id[:8]}" in normalized_err
-    assert f"jj-stack submit {connected_head_change_id[:8]}" in normalized_err
-    # The unrelated stack also changed but is not built on the selected head, so
-    # it stays silent.
-    assert unrelated_head_change_id[:8] not in captured.err
-    assert f"jj-stack view {unrelated_head_change_id[:8]}" not in normalized_err
-    assert f"jj-stack submit {unrelated_head_change_id[:8]}" not in normalized_err
-
-
-def test_view_warns_after_middle_change_is_split_into_sibling_stack(
+def test_view_change_id_rejects_multiple_containing_paths(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -276,15 +255,11 @@ def test_view_warns_after_middle_change_is_split_into_sibling_stack(
     run_command(["jj", "rebase", "-s", change_c, "-d", change_a], repo)
     run_command(["jj", "edit", change_b], repo)
 
-    exit_code = run_main(repo, config_path, "view")
+    exit_code = run_main(repo, config_path, "view", change_a[:8])
     captured = capsys.readouterr()
-    normalized_err = " ".join(captured.err.split())
 
-    assert exit_code == 0
-    assert change_c[:8] in captured.err
-    assert "changed since its last submit" in captured.err
-    assert f"jj-stack view {change_c[:8]}" in normalized_err
-    assert f"jj-stack submit {change_c[:8]}" in normalized_err
+    assert exit_code == EXIT_AMBIGUOUS
+    assert "resolved to more than one revision" in captured.err
 
 
 def test_view_pull_request_selector_requires_a_linked_local_change(

--- a/tests/unit/test_review_path.py
+++ b/tests/unit/test_review_path.py
@@ -107,7 +107,7 @@ def test_only_explicit_revision_selection_can_project_a_sole_trunk_copy() -> Non
     )
 
     assert explicit.stack.revisions == ()
-    with pytest.raises(CliError, match="no mutable local copy"):
+    with pytest.raises(CliError, match="already on trunk"):
         project_selected_path(
             _observation(
                 head=trunk_copy,


### PR DESCRIPTION
Treat a PR or bare change ID as identifying its unique containing
stack, while leaving arbitrary revsets as exact head selectors. Remove
the connected-stack advisory that existed for the old prefix behavior,
and fail closed when local history has multiple containing heads.

Clarify that a change found only on trunk is no longer part of a local
stack.