### PR TITLE
merge: sync completed direct merges locally

### DIFF
--- a/docs/daily-workflow.md
+++ b/docs/daily-workflow.md
@@ -243,6 +243,9 @@ To stop the selected bottom portion at one pull request:
 jj-stack merge --pull-request 7
 ```
 
+That pull request sets only the merge boundary. After a direct merge, `merge` still updates the
+whole local stack containing it, including higher changes whose review branches GitHub rewrote.
+
 For a direct merge, the merge method comes from repository settings when only one is enabled.
 When several are, set a default once:
 
@@ -264,31 +267,38 @@ GitHub handles both one-PR and multi-PR selections through its asynchronous merg
 operation merges nothing. GitHub may rewrite the branches for PRs that remain above a partial
 selection.
 
-When trunk uses a merge queue, `merge` returns successfully once GitHub accepts the selected PRs:
+When trunk uses a merge queue, `merge` returns successfully once GitHub reports that the selected
+PRs are in the queue:
 
 ```text
-Added to merge queue:
-  ✓ GitHub merge request: add PRs #41, #42 to the merge queue for main
+In merge queue:
+  ✓ GitHub merge request: PRs #41, #42 are queued for main through commit abc123
 GitHub will merge them once the queue processes them.
 ```
 
 That result does not mean trunk changed. `view` and `list` show the PRs as queued. Wait for GitHub
 to merge them before running `sync`; there is no queue watcher in `jj-stack`.
 
-`merge` does not rewrite local history, refresh surviving PRs, or remove tracking. After GitHub
-merges anything, run the `jj-stack sync <head-change-id>` command printed in the result. If an
-identical stack request is already pending, wait and rerun the same explicit `merge` command; once
-GitHub
-finishes, the retry observes the completed result.
+When a direct merge completes, `merge` fetches the result, removes the merged local changes,
+rebases any selected survivors, and updates their existing PRs before returning. If that local
+update stops, the command says that GitHub already completed the merge; do not run `merge` again.
+It continues with the containing-stack head that it resolved before merging, even if the original
+selector was a revision expression whose meaning changed with trunk. Follow its recovery
+instructions, which may include rerunning `sync` with that head change ID.
 
-While an open PR is queued, `submit` will not update its review branch or PR, and `sync` leaves
-the selected stack alone. Wait for it to merge or remove it from the queue first. Independent
-stacks remain usable.
+If an identical stack request is already pending, wait and rerun the same explicit `merge`
+command. Once GitHub finishes, the retry observes the completed result and updates the local
+stack.
+
+While an open PR is queued, `submit` makes no changes to its selected stack. New local changes
+above the queued PR remain unsubmitted. Wait for the queued changes to merge, run `sync` with the
+new head change ID, then run `submit` with that same change ID. `sync` also leaves a queued stack
+alone. Independent stacks remain usable.
 
 ## 7. Update a stack after GitHub merged lower PRs
 
-Use `sync` with the stack's head change ID after `merge`, or whenever GitHub merged lower PRs
-through different commit IDs and your local stack still contains the old commits:
+Use `sync` with the stack's head change ID after a queued or externally completed merge, or when
+automatic sync stopped and your local stack still contains old merged commits:
 
 ```bash
 jj-stack sync <head-change-id>
@@ -421,10 +431,7 @@ jj-stack submit
 # edit in jj
 jj-stack submit
 jj-stack merge
-jj-stack sync <head-change-id>
 ```
-
-Use the head change ID printed by `merge`.
 
 ## When something goes wrong
 
@@ -452,10 +459,9 @@ jj-stack sync <head-change-id>
 jj-stack sync --all --dry-run
 jj-stack sync --all
 
-# merge after GitHub accepted one or more PRs: reconcile, then retry if desired
+# merge completed on GitHub but automatic sync stopped: reconcile; do not rerun merge
 jj-stack sync --dry-run <head-change-id>
 jj-stack sync <head-change-id>
-jj-stack merge <head-change-id>
 ```
 
 Use explicit selectors after a failure, not a naked command that falls back to

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -30,6 +30,8 @@ Notes:
   together with the payload. See [json-output.md](json-output.md).
 - Commands that mutate review state (`submit`, `merge`, `sync`, `unstack`, `cleanup`) exit 1 when
   they ran but had to stop before completing every action; command output names what blocked them.
+- A direct `merge` can complete on GitHub and still return a nonzero code when its automatic local
+  sync stops. The output distinguishes those outcomes and says not to retry the merge.
 - `sync` may finish its local rebase before exiting 3. Its message says whether to resolve the
   conflicts and continue with `submit`.
 - Exit 2 covers selections `jj-stack` cannot review as a linear stack: a merge commit, a divergent

--- a/docs/internals/design.md
+++ b/docs/internals/design.md
@@ -49,9 +49,11 @@ The normal lifecycle is:
 2. Use `jj-stack view` to inspect the stack, and `jj-stack list` to see all stacks.
 3. Use `jj-stack submit` to create or refresh the PRs for that selected stack.
 4. After another local rewrite, run `submit` again; existing reviews follow their change IDs.
-5. Use `jj-stack merge` to ask GitHub to merge a reviewed prefix from the bottom.
-6. Run `jj-stack sync` for that selected stack. It fetches GitHub's result, then reconciles the
-   remaining local changes and reviews with what reached trunk.
+5. Use `jj-stack merge` to ask GitHub to merge a reviewed prefix from the bottom. When GitHub
+   completes a direct merge, the same command fetches its result and reconciles the remaining
+   local changes and reviews with what reached trunk.
+6. After a queued merge, or a merge completed outside `jj-stack`, run `jj-stack sync` for that
+   selected stack once GitHub has finished.
 
 ## Core concepts
 
@@ -218,8 +220,9 @@ evidence, and mutation rules.
   reviews proven on trunk by exact submitted-commit evidence, but never rewrites local stacks or
   submits work. A tracking record or GitHub review that cannot be read does not block independent
   candidates.
-- **`merge`** is the only command that asks GitHub to merge. It never pushes trunk or rewrites
-  local history.
+- **`merge`** is the only command that asks GitHub to merge. It never pushes trunk. After GitHub
+  completes a direct merge, it immediately performs the same selected-stack reconciliation as
+  `sync`; queue acceptance leaves local history alone.
 - **`unstack`** removes GitHub's stack grouping while leaving its pull requests open. A GitHub
   stack number selects the remote resource directly; otherwise a local review stack selects its
   matching GitHub stack. `--local` only forgets local tracking and does not change GitHub.
@@ -237,9 +240,11 @@ evidence, and mutation rules.
 
 There is no standalone `rebase` command; `jj` owns general descendant rewrites.
 
-`sync`, `merge`, and `checkout --fetch` run `jj git fetch` themselves before they act. No other
-command fetches, so the user runs `jj git fetch` when local trunk is stale. **Fetched trunk**
-below always means `trunk()` as evaluated after the running command's own fetch.
+`sync`, `merge`, and `checkout --fetch` run `jj git fetch` themselves before they act. A direct
+`merge` fetches once while preparing the GitHub request and again after GitHub completes it so
+local reconciliation observes the result. No other command fetches, so when local trunk is stale
+the user runs `jj git fetch`. **Fetched trunk** below always means `trunk()` as evaluated after the
+running command's relevant fetch.
 
 ## Sources of truth
 
@@ -449,14 +454,20 @@ post-check detects GitHub-side changes that the pre-push model could not prevent
 them by silently replacing tracking.
 
 An open PR currently in a merge queue is not updated. `submit` stops the selected stack before
-moving any review branch or changing any PR, and tells the user to wait for the queue or remove
-the PR from it. This does not restrict commands on independent stacks.
+moving any review branch or changing any PR, and tells the user to wait for GitHub to merge it.
+This does not restrict commands on independent stacks.
 
 ### Merge
 
 `merge` considers a contiguous prefix from the bottom of the selected stack. Candidates must be
 open and non-draft. The first draft or closed-unmerged review blocks itself and everything above.
 `--pull-request` truncates the candidate prefix at the selected linked PR.
+
+A pull request selector still selects the complete local stack containing that PR; it changes
+only the merge boundary. After a direct prefix merge, automatic reconciliation therefore covers
+the unmerged changes above that boundary too, including survivor commits GitHub rewrote. An exact
+revision expression retains its ordinary exact-head selection and cannot omit active members of
+the GitHub stack.
 
 GitHub receives one asynchronous merge request for the selected prefix, whether it contains one
 PR or several. A multi-PR request acts on the matching GitHub stack. Every request passes the
@@ -467,10 +478,21 @@ queue object or a `MERGE_QUEUE` branch rule. If that lookup fails, `merge` follo
 direct-merge path and lets the merge request report any policy rejection. It sends the explicit
 action `merge_queue` when a queue is found and `direct_merge` otherwise.
 
-A terminal `merged` result means a direct merge completed. A terminal `enqueued` result means
-GitHub accepted the selected PRs into the queue; it is successful but does not imply that trunk
-changed or that `sync` should run yet. A rejection changes no local history, and a later command
-observes whatever GitHub reports.
+A terminal `merged` result means a direct merge completed. `merge` then fetches and runs selected
+stack reconciliation before returning. A terminal `enqueued` result means GitHub accepted the
+selected PRs into the queue; it is successful but does not imply that trunk changed or that
+`sync` should run yet. A rejection changes no local history, and a later command observes
+whatever GitHub reports.
+
+Automatic reconciliation identifies the containing stack by the full change ID of the head
+resolved before the merge request. It does not reinterpret the original revision expression
+after fetching the changed trunk.
+
+GitHub merge success and local reconciliation are separate outcomes. If GitHub completes the
+merge but the automatic sync stops, `merge` returns the sync failure status, says that the GitHub
+merge must not be retried, and preserves the ordinary observational recovery path. The next
+`sync` rereads GitHub, fetched trunk, the local DAG, and tracking rather than resuming saved
+operation state.
 
 For a direct merge, the merge method comes from `--method`, otherwise from `merge_method` in
 repository configuration, otherwise from the repository's only allowed method. GitHub reports

--- a/docs/internals/implementation-strategy.md
+++ b/docs/internals/implementation-strategy.md
@@ -316,7 +316,8 @@ state directory contains no operation journal, merge note, phase, selector, path
 resource ID, or recovery checkpoint.
 
 Merge and recovery share current-state observation rather than a durable operation state
-machine:
+machine. A terminal direct merge invokes selected convergence under the merge command's existing
+repository lock; queued and blocked results return without doing so:
 
 - `commands/merge/` checks and asks GitHub to merge one selected review path
 - `commands/sync.py` repairs a selected stack
@@ -516,9 +517,9 @@ branch state, not just JSON responses.
 
 Its GitHub stack endpoints model ordered resource membership, historical merged prefixes, exact
 active suffix unstacking, create/append admission, and asynchronous merge submission and polling.
-The merge fixtures cover direct merges, queue acceptance, atomic failure, partial survivor
-rewrites, and terminal retry. They remain bounded contracts rather than a general GitHub stack
-emulator.
+The merge fixtures cover direct merge convergence, queue acceptance, atomic failure, a middle-PR
+boundary with higher survivor rewrites, a post-merge local failure, and terminal retry. They
+remain bounded contracts rather than a general GitHub stack emulator.
 
 We use FastAPI for the fake server unless Starlette later proves to offer a clear
 concrete advantage for this test harness.

--- a/docs/internals/property-testing.md
+++ b/docs/internals/property-testing.md
@@ -174,10 +174,11 @@ repository-wide sync eligibility.
 
 The stack-merge tests assert both final Git and PR state and the significant API events. A
 terminal stack-merge failure changes nothing. A successful partial request may change survivor
-heads and bases, but `merge` does not rewrite local history; `sync` validates and
-converges that remote
-transition. These are bounded command contracts, not generated merge property families or a
-durable recovery state machine.
+heads and bases. A terminal direct `merge` validates and converges that transition before
+returning, including when a middle pull request names the merge boundary but higher survivors
+were not named by the user. Queue acceptance leaves local history alone, and a remote-success /
+local-failure case proves the outcomes remain distinguishable. These are bounded command
+contracts, not generated merge property families or a durable recovery state machine.
 
 ## Interrupted-submit retry harness
 

--- a/docs/mental-model.md
+++ b/docs/mental-model.md
@@ -26,9 +26,10 @@ Each review branch is named `<prefix>/<subject-slug>-<short-change-id>`, where `
 `jj-stack` unless the repo sets `branch_prefix`. The readable subject hints at the change's
 purpose; the suffix ties the name to its stable change ID. The branches normally stay on the Git
 remote, so they do not clutter local `jj` bookmark output. `jj-stack` creates them for review and
-can remove them later with `jj-stack cleanup` after their pull requests close or merge.
-Merging itself does not rewrite local history or remove review state. Run
-`jj-stack sync <head-change-id>` afterward to bring local history in line with what GitHub did.
+can remove them later with `jj-stack cleanup` after their pull requests close or merge. When
+GitHub completes a direct merge, `jj-stack merge` immediately fetches and brings local history in
+line with it. After a queued merge or a merge completed through another client, run
+`jj-stack sync <head-change-id>` once GitHub finishes.
 
 ## Stack structure
 
@@ -82,4 +83,5 @@ When in doubt:
 - use `jj-stack view` to inspect the matching GitHub PR stack
 - use `jj-stack submit` to refresh that PR stack
 - use `jj-stack merge` to ask GitHub to merge the reviewed bottom changes
-- use `jj-stack sync <head-change-id>` afterward to bring local history in line
+- use `jj-stack sync <head-change-id>` after a queued or externally completed merge, or to
+  continue when automatic sync reports a local problem

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -276,9 +276,24 @@ What to do:
   into it. This is not a merge failure and does not mean trunk changed. `view` and `list` show the
   PRs as queued; wait for GitHub to merge them before running `sync`.
 - While a PR is queued, `submit` will not move its review branch or change the PR, and `sync`
-  leaves that selected stack alone. Wait for it to merge or remove it from the queue. Other
-  stacks remain usable.
+  leaves that selected stack alone. Wait for it to merge. Other stacks remain usable.
 - An access-denied response is a permissions problem. Fix repository permissions before retrying.
+
+## `merge` completed on GitHub but could not update the local stack
+
+The pull requests are already merged. Do not rerun `merge`: the command's nonzero exit describes
+the later local sync failure, not a failed GitHub merge.
+
+Follow the recovery instruction printed with the error. If it does not name a more specific
+command, inspect and continue from current state with:
+
+```bash
+jj-stack view <head-change-id>
+jj-stack sync <head-change-id>
+```
+
+No merge journal needs repairing. `sync` fetches again and derives the remaining work from
+GitHub, trunk, the local `jj` DAG, and tracking.
 
 ## PRs for this stack exist on GitHub but `jj-stack` doesn't know about them
 
@@ -457,8 +472,9 @@ each time.
   `jj-stack sync <head-change-id>`.
 - `sync --all`: preview with `jj-stack sync --all --dry-run`, then run
   `jj-stack sync --all`.
-- `merge`: rerun the same explicit selector and merge method. A matching request still in progress
-  asks you to wait; a completed or enqueued request is observed on retry.
+- `merge`: rerun the same explicit selector and merge method only when GitHub did not complete the
+  request. A matching request still in progress asks you to wait. If GitHub completed the merge
+  but automatic sync stopped, do not rerun `merge`; follow the printed local recovery instead.
 
 `jj-stack sync <head-change-id>` handles commits rewritten by GitHub while keeping a review
 branch that a PR above still needs. `sync --all` checks independently tracked exact commits

--- a/skills/jj-stack/SKILL.md
+++ b/skills/jj-stack/SKILL.md
@@ -96,8 +96,9 @@ confirms after you explain that risk.
   approvals, checks, conflicts, and repository policy. Multi-PR reviews use
   one atomic bottom-prefix request; the same asynchronous API handles a one-PR
   review. If trunk uses a merge queue, success means GitHub accepted the PRs
-  into the queue, not that they merged. It never pushes trunk or rewrites local
-  history. Wait for queued PRs to merge, then run `sync <head-change-id>`.
+  into the queue, not that they merged. A completed direct merge automatically
+  fetches and syncs the selected local stack; it never pushes trunk. Wait for
+  queued PRs to merge, then run `sync <head-change-id>`.
 - **Remove GitHub stack grouping:** `unstack --dry-run <head-change-id>`, then
   `unstack <head-change-id>`. When one GitHub stack spans several desired local
   paths, use the exact `unstack --stack <number>` command from the diagnostic.
@@ -149,8 +150,9 @@ you see.
 4. Apply review feedback in the change it belongs to: edit the lower `jj`
    change, let descendants rebase, then `view` and `submit`. Do not patch a
    higher change to avoid touching a lower one.
-5. When bottom changes are ready, `merge --dry-run`, then `merge`, followed
-   by the printed `sync <head-change-id>`.
+5. When bottom changes are ready, `merge --dry-run`, then `merge`. A completed
+   direct merge updates the local stack automatically. After a queued merge,
+   run `sync <head-change-id>` once GitHub finishes.
 6. If `trunk()` merely advanced, use plain `jj rebase`. `sync` is for
    ancestors already merged on GitHub under exact or rewritten commit IDs.
 
@@ -169,9 +171,11 @@ that is incomplete or needs attention (the output is still valid — read it);
   access reason, fix it, and rerun the same explicit command. A terminal
   stack-merge failure merges nothing. A matching request already pending should
   be allowed to finish, then observed by rerunning the same target and method.
+- Direct merge completed but automatic sync failed: do not rerun `merge`.
+  Follow the reported recovery instructions; `sync <head-change-id>` can
+  continue from current GitHub, trunk, local, and tracking observations.
 - Queued review: `view` and `list` report it. Do not submit or sync that stack
-  until GitHub merges it or the PR is removed from the queue. Independent stacks
-  remain usable.
+  until GitHub merges it. Independent stacks remain usable.
 - Interrupted command: `view`, then rerun with an explicit change ID, revset,
   or `--pull-request` selector.
 - jj-stack reports ambiguity (exit 6): stop and ask for a concrete selector.

--- a/src/jj_stack/cli.py
+++ b/src/jj_stack/cli.py
@@ -68,7 +68,8 @@ changes, and clean up after a review. Keep creating and editing changes with `jj
 handles the GitHub review workflow around them.
 
 Running `jj-stack` with no command shows the current stack. A typical workflow is
-`jj-stack submit`, `jj-stack view`, `jj-stack merge`, then the printed `jj-stack sync` command.
+`jj-stack submit`, `jj-stack view`, then `jj-stack merge`. A completed direct merge updates the
+local stack; a queued or externally completed merge is reconciled later with `jj-stack sync`.
 """
 _REORDERABLE_GLOBAL_FLAGS = frozenset({"--debug", "--time-output"})
 _REORDERABLE_GLOBAL_OPTIONS_WITH_VALUES = frozenset({"--repository", "--color"})
@@ -365,7 +366,7 @@ def build_parser() -> ArgumentParser:
         merge_parser,
         *_PULL_REQUEST_OPTION_STRINGS,
         metavar="PR",
-        help="Merge up to and including this pull request number or URL, and no further",
+        help=("Merge this PR and all PRs below it; after a direct merge, sync the entire stack"),
     )
     add_help_argument(
         merge_parser,

--- a/src/jj_stack/commands/merge/command.py
+++ b/src/jj_stack/commands/merge/command.py
@@ -4,9 +4,13 @@ Candidates are the consecutive open, non-draft pull requests from the bottom. Ea
 match the exact commit last submitted; GitHub decides whether reviews, checks, conflicts, and
 repository rules allow the merge.
 
-GitHub merges one PR or a multi-PR prefix through its asynchronous merge API. When the trunk
-branch uses a merge queue, the command adds the reviewed changes to that queue. This command does
-not update local history or remove review state.
+For a direct merge, the command waits for GitHub to finish. It then fetches trunk, removes the
+merged changes from the local stack, rebases any remaining changes onto the updated trunk, and
+updates their existing pull requests.
+
+When the trunk branch uses a merge queue, the command adds the changes to the queue and exits as
+soon as GitHub accepts them. It does not wait for them to merge or update the local stack. After
+GitHub finishes, run `jj-stack sync <head-change-id>`.
 
 Common examples:
 
@@ -27,6 +31,7 @@ import jj_stack.console as console
 import jj_stack.ui as ui
 from jj_stack.bootstrap import CommandContext, bootstrap_context
 from jj_stack.commands._github_stack_safety import GithubStackSelection
+from jj_stack.commands.sync import run_stack_convergence
 from jj_stack.config import MergeMethod
 from jj_stack.errors import CliError
 from jj_stack.github.client import GithubClientError, build_github_client
@@ -104,7 +109,39 @@ def _run_merge(
         )
     result = asyncio.run(_stream_merge_async(prepared_merge=prepared_merge))
     print_merge_result(result)
-    return 1 if result.blocked else 0
+    if result.blocked:
+        return 1
+    if result.enqueued or not result.applied:
+        return 0
+    sync_change_id = prepared_merge.prepared_status.prepared.stack.head.change_id
+    console.output("Updating the local stack after the completed merge:")
+    try:
+        exit_code = run_stack_convergence(
+            context=context,
+            dry_run=False,
+            fetch_remote_state=True,
+            revset=sync_change_id,
+        )
+    except BaseException as error:
+        _warn_incomplete_post_merge_sync(sync_change_id)
+        if isinstance(error, GithubClientError):
+            raise CliError(
+                "Could not update the local stack after the completed merge.",
+                hint=t"Resolve the GitHub error, then run "
+                t"{ui.cmd(f'jj-stack sync {sync_change_id}')}",
+            ) from error
+        raise
+    if exit_code:
+        _warn_incomplete_post_merge_sync(sync_change_id)
+    return exit_code
+
+
+def _warn_incomplete_post_merge_sync(sync_change_id: str) -> None:
+    console.warning(
+        t"GitHub completed the merge, but the local stack update did not finish. Do not run "
+        t"{ui.cmd('jj-stack merge')} again. Continue with "
+        t"{ui.cmd(f'jj-stack sync {sync_change_id}')}."
+    )
 
 
 def _resolve_merge_target(

--- a/src/jj_stack/commands/merge/github_stack.py
+++ b/src/jj_stack/commands/merge/github_stack.py
@@ -37,13 +37,16 @@ class AsyncMergePlan:
     def action(
         self,
         *,
+        enqueued: bool = False,
         merge_action: str,
         method: str | None,
         trunk_branch: str,
     ) -> MergeAction:
         number_list = ", ".join(f"#{revision.identity.pr_number}" for revision in self.planned)
         pull_requests = f"PR {number_list}" if len(self.planned) == 1 else f"PRs {number_list}"
-        if merge_action == "merge_queue":
+        if merge_action == "merge_queue" and enqueued:
+            body = t"{pull_requests} are queued for {ui.bookmark(trunk_branch)} through "
+        elif merge_action == "merge_queue":
             body = (
                 t"add {pull_requests} to the merge queue for {ui.bookmark(trunk_branch)} through "
             )
@@ -348,6 +351,7 @@ def _enqueued_result(
 ) -> MergeResult:
     action = replace(
         merge.action(
+            enqueued=True,
             merge_action=merge_action,
             method=None,
             trunk_branch=execution.trunk_branch,

--- a/src/jj_stack/commands/merge/render.py
+++ b/src/jj_stack/commands/merge/render.py
@@ -40,16 +40,11 @@ def print_merge_result(result: MergeResult) -> None:
         )
     if result.enqueued:
         console.output("GitHub will merge them once the queue processes them.")
-    elif result.applied:
-        console.output(
-            t"GitHub accepted one or more merges. Run "
-            t"{ui.cmd(f'jj-stack sync {result.selected_revset}')} to update the local stack."
-        )
 
 
 def _result_header(result: MergeResult) -> str:
     if result.enqueued:
-        return "Added to merge queue:"
+        return "In merge queue:"
     if result.applied:
         return "Applied merge actions:"
     if result.blocked:

--- a/src/jj_stack/commands/submit/pull_requests.py
+++ b/src/jj_stack/commands/submit/pull_requests.py
@@ -67,10 +67,14 @@ def ensure_pull_request_syncs_are_safe(
         submitted_baseline = state.submitted_baselines.get(change_id)
         pull_request = pending_sync.discovered_pull_request
         if pull_request is not None and pull_request.is_queued:
+            head_change_id = pending_syncs[-1].prepared.revision.change_id
             raise CliError(
                 t"PR #{pull_request.number} for {ui.change_id(change_id)} is in the merge "
-                t"queue, so submit will not change its review branch or pull request.",
-                hint="Wait for it to merge or remove it from the queue, then rerun submit.",
+                t"queue, so submit made no changes. Any new changes above it remain "
+                t"unsubmitted.",
+                hint=t"Wait for the queued changes to merge, then run "
+                t"{ui.cmd(f'jj-stack sync {head_change_id}')} followed by "
+                t"{ui.cmd(f'jj-stack submit {head_change_id}')}.",
             )
         _ensure_pull_request_link_is_consistent(
             branch=prepared_revision.branch,

--- a/tests/integration/test_merge_command.py
+++ b/tests/integration/test_merge_command.py
@@ -58,9 +58,22 @@ def test_merge_queue_accepts_single_and_stacked_reviews_without_a_merge_method(
     )
     assert read_remote_ref(fake_repo.git_dir, "main") == trunk_before
     assert "ignoring --method" in captured.err
-    assert "Added to merge queue" in captured.out
+    assert "In merge queue" in captured.out
+    assert "are queued for main" in captured.out
+    assert "Added to merge queue" not in captured.out
     assert "once the queue processes them" in captured.out
     assert "jj-stack sync" not in captured.out
+
+    repeated_exit_code = run_main(repo, config_path, "merge")
+    repeated = capsys.readouterr()
+
+    assert repeated_exit_code == 0, (repeated.out, repeated.err)
+    assert "In merge queue" in repeated.out
+    assert "are queued for main" in repeated.out
+    assert "Added to merge queue" not in repeated.out
+    assert fake_repo.stack_merge_requests == [
+        (stack_size, None, "merge_queue", stack.head.commit_id)
+    ]
 
 
 def test_merge_queue_lookup_failure_falls_back_to_direct_merge(
@@ -138,68 +151,55 @@ def test_merge_draft_blocks_the_candidate_prefix(
     assert read_remote_ref(fake_repo.git_dir, "main") == trunk_before
 
 
-def test_stack_merge_rebases_ready_prefix_and_reports_closed_boundary(
+def test_stack_merge_reports_github_failure_during_automatic_sync(
     tmp_path: Path,
     monkeypatch,
     capsys,
 ) -> None:
-    repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=3)
+    repo, fake_repo = init_fake_github_repo_with_submitted_feature(tmp_path)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    fake_repo.allow_rebase_merge = True
-    fake_repo.github_stacks = {7: (1, 2, 3)}
-    fake_repo.pull_requests[3].state = "closed"
     state_store = ReviewStateStore.for_repo(repo)
     stack_before = selected_stack(repo)
     state_before = state_store.load()
     trunk_before = read_remote_ref(fake_repo.git_dir, "main")
-    survivor_before = fake_repo.ref_target(fake_repo.pull_requests[3].head_ref)
+    app = create_app(FakeGithubState.single_repository(fake_repo))
 
-    preview_exit_code = run_main(
-        repo,
-        config_path,
-        "merge",
-        "--dry-run",
-        "--pull-request",
-        "2",
-        "--method",
-        "rebase",
+    class SyncRepositoryFailureClient(GithubClient):
+        async def get_repository(self):
+            raise GithubClientError("sync repository lookup failed")
+
+    patch_github_client_builders(
+        monkeypatch,
+        app=app,
+        fake_repo=fake_repo,
+        modules=("jj_stack.commands.sync",),
+        client_type=SyncRepositoryFailureClient,
     )
-    preview = capsys.readouterr()
 
-    assert preview_exit_code == 0, (preview.out, preview.err)
-    assert "merge PRs #1, #2" in preview.out
-    assert fake_repo.stack_merge_requests == []
-
-    exit_code = run_main(
-        repo,
-        config_path,
-        "merge",
-        "--method",
-        "rebase",
-    )
+    exit_code = run_main(repo, config_path, "merge")
     captured = capsys.readouterr()
 
-    assert exit_code == 0, (captured.out, captured.err)
+    assert exit_code == 4
     assert fake_repo.stack_merge_requests == [
-        (2, "rebase", "direct_merge", stack_before.revisions[1].commit_id)
+        (1, "squash", "direct_merge", stack_before.head.commit_id)
     ]
-    assert fake_repo.stack_merge_polls == [(2, "fake-stack-merge-1")]
     assert fake_repo.pull_requests[1].state == "closed"
-    assert fake_repo.pull_requests[2].state == "closed"
-    assert fake_repo.pull_requests[3].state == "closed"
-    assert fake_repo.pull_requests[3].base_ref == "main"
-    assert fake_repo.ref_target(fake_repo.pull_requests[3].head_ref) != survivor_before
     assert read_remote_ref(fake_repo.git_dir, "main") != trunk_before
     assert "final trunk commit" in captured.out
-    assert "stop:" in captured.out
-    assert "sync " in captured.out
+    assert "Updating the local stack after the completed merge" in captured.out
+    error = " ".join(captured.err.split())
+    assert "GitHub completed the merge, but the local stack update did not finish" in error
+    assert "Do not run jj-stack merge again" in error
+    assert f"jj-stack sync {stack_before.head.change_id}" in error
+    assert "Could not update the local stack after the completed merge" in error
+    assert "request failed (sync repository lookup failed)" in error
     assert state_store.load() == state_before
     assert tuple(revision.commit_id for revision in selected_stack(repo).revisions) == tuple(
         revision.commit_id for revision in stack_before.revisions
     )
 
 
-def test_stack_merge_commit_uses_one_group_result_that_sync_can_retire(
+def test_stack_merge_commit_uses_resolved_head_for_automatic_sync(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -217,6 +217,7 @@ def test_stack_merge_commit_uses_one_group_result_that_sync_can_retire(
         "merge",
         "--method",
         "merge",
+        "heads(trunk()..@-)",
     )
     merged = capsys.readouterr()
     merge_commit = fake_repo.pull_requests[1].merge_commit_sha
@@ -229,16 +230,13 @@ def test_stack_merge_commit_uses_one_group_result_that_sync_can_retire(
         fake_repo.is_ancestor(revision.commit_id, merge_commit) for revision in stack.revisions
     )
 
-    sync_exit_code = run_main(repo, config_path, "sync", stack.head.change_id)
-    synced = capsys.readouterr()
-
-    assert sync_exit_code == 0, (synced.out, synced.err)
+    assert "Updating the local stack after the completed merge" in merged.out
     assert state_store.load().review_identities == {}
     assert JjClient(repo).resolve_revision("@").parents == (merge_commit,)
 
 
 @pytest.mark.parametrize("merge_method", ("rebase", "squash"))
-def test_stack_rewriting_merge_sync_retires_pre_merge_copies(
+def test_stack_rewriting_merge_automatically_retires_pre_merge_copies(
     tmp_path: Path,
     monkeypatch,
     capsys,
@@ -258,10 +256,7 @@ def test_stack_rewriting_merge_sync_retires_pre_merge_copies(
     assert merge_exit_code == 0, (merged.out, merged.err)
     assert final_trunk == read_remote_ref(fake_repo.git_dir, "main")
 
-    sync_exit_code = run_main(repo, config_path, "sync", stack.head.change_id)
-    synced = capsys.readouterr()
-
-    assert sync_exit_code == 0, (synced.out, synced.err)
+    assert "Updating the local stack after the completed merge" in merged.out
     assert state_store.load().review_identities == {}
     assert JjClient(repo).resolve_revision("@").parents == (final_trunk,)
     copies = JjClient(repo).query_revisions_by_change_ids(
@@ -365,7 +360,6 @@ def test_stack_merge_recovers_only_from_a_terminal_retry(
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     fake_repo.github_stacks = {7: (1, 2)}
     state_store = ReviewStateStore.for_repo(repo)
-    state_before = state_store.load()
     app = create_app(FakeGithubState.single_repository(fake_repo))
 
     class LostResponseClient(GithubClient):
@@ -417,7 +411,10 @@ def test_stack_merge_recovers_only_from_a_terminal_retry(
     assert fake_repo.stack_merge_polls == []
     assert len(fake_repo.stack_merge_requests) == 1
     assert tuple(pr.state for pr in fake_repo.pull_requests.values()) == ("closed", "closed")
-    assert state_store.load() == state_before
+    assert state_store.load().review_identities == {}
+    assert JjClient(repo).resolve_revision("@").parents == (
+        read_remote_ref(fake_repo.git_dir, "main"),
+    )
 
 
 def test_stack_merge_requires_a_resource_for_a_multi_pr_review(

--- a/tests/integration/test_submit_command.py
+++ b/tests/integration/test_submit_command.py
@@ -170,27 +170,36 @@ def test_submit_github_stack_recovers_lost_create_and_retries_blocked_append(
     )
 
 
-def test_submit_does_not_update_a_queued_review(
+def test_submit_leaves_new_suffix_unsubmitted_while_an_ancestor_is_queued(
     tmp_path: Path,
     monkeypatch,
     capsys,
 ) -> None:
     repo, fake_repo = init_fake_github_repo_with_submitted_feature(tmp_path)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    revision = selected_stack(repo).head
     pull_request = fake_repo.pull_requests[1]
     pull_request.is_queued = True
-    remote_before = fake_repo.ref_target(pull_request.head_ref)
-    title_before = pull_request.title
-    run_command(["jj", "describe", "-r", revision.change_id, "-m", "renamed feature"], repo)
+    remote_before = remote_refs(fake_repo.git_dir)
+    state_store = ReviewStateStore.for_repo(repo)
+    state_before = state_store.load()
+    commit_file(repo, "feature 2", "feature-2.txt")
+    commit_file(repo, "feature 3", "feature-3.txt")
+    head_change_id = selected_stack(repo).head.change_id
 
     exit_code = run_main(repo, config_path, "submit")
     captured = capsys.readouterr()
 
     assert exit_code == 1
-    assert "is in the merge queue" in captured.err
-    assert fake_repo.ref_target(pull_request.head_ref) == remote_before
-    assert pull_request.title == title_before
+    error = " ".join(captured.err.split())
+    assert "is in the merge queue" in error
+    assert "submit made no changes" in error
+    assert "new changes above it remain unsubmitted" in error
+    assert f"jj-stack sync {head_change_id}" in error
+    assert f"jj-stack submit {head_change_id}" in error
+    assert "remove PR #1 from the queue" not in error
+    assert tuple(fake_repo.pull_requests) == (1,)
+    assert remote_refs(fake_repo.git_dir) == remote_before
+    assert state_store.load() == state_before
 
 
 def test_submit_recreates_github_stack_only_after_active_review_grows_to_two(

--- a/tests/integration/test_sync_command.py
+++ b/tests/integration/test_sync_command.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import re
 from copy import deepcopy
 from pathlib import Path
 
@@ -145,38 +144,37 @@ def test_sync_recovers_a_clean_single_review_rebase_merge(
     assert reviewed.change_id not in state_store.load().review_identities
 
 
-def test_merge_prints_a_short_sync_target_that_converges_the_local_stack(
+def test_merge_by_middle_pull_request_automatically_syncs_the_unnamed_survivors(
     tmp_path: Path,
     monkeypatch,
     capsys,
 ) -> None:
-    repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
+    repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=4)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    fake_repo.pull_requests[2].is_draft = True
     stack = selected_stack(repo)
-    top_change_id = stack.revisions[1].change_id
-    top_commit_id = stack.revisions[1].commit_id
-    abbreviated_change_id = top_change_id[:8]
+    survivors = stack.revisions[2:]
+    survivor_commits_before = tuple(revision.commit_id for revision in survivors)
 
-    merge_exit_code = run_main(repo, config_path, "merge", abbreviated_change_id)
+    merge_exit_code = run_main(repo, config_path, "merge", "--pull-request", "2")
     merged = capsys.readouterr()
-    assert merge_exit_code == 0
-    assert fake_repo.pull_requests[1].merged_at is not None
-    assert fake_repo.pull_requests[2].state == "open"
-    assert JjClient(repo).resolve_revision(top_change_id).commit_id == top_commit_id
-    match = re.search(r"jj-stack sync\s+([k-z]+)", merged.out)
-    assert match is not None, merged.out
-    assert match.group(1) == abbreviated_change_id
 
-    sync_exit_code = run_main(repo, config_path, "sync", match.group(1))
-    captured = capsys.readouterr()
-
-    assert sync_exit_code == 0, (captured.out, captured.err)
+    assert merge_exit_code == 0, (merged.out, merged.err)
+    assert all(fake_repo.pull_requests[number].merged_at is not None for number in (1, 2))
+    assert all(fake_repo.pull_requests[number].state == "open" for number in (3, 4))
+    assert "Updating the local stack after the completed merge" in merged.out
     merged_trunk_commit = read_remote_ref(fake_repo.git_dir, "main")
-    rewritten_top = JjClient(repo).resolve_revision(top_change_id)
-    assert rewritten_top.parents == (merged_trunk_commit,)
-    assert fake_repo.pull_requests[2].base_ref == "main"
-    assert fake_repo.pull_requests[2].state == "open"
+    rewritten_survivors = tuple(
+        JjClient(repo).resolve_revision(revision.change_id) for revision in survivors
+    )
+    rewritten_commits = tuple(revision.commit_id for revision in rewritten_survivors)
+    assert rewritten_commits != survivor_commits_before
+    assert rewritten_commits == tuple(
+        fake_repo.ref_target(fake_repo.pull_requests[number].head_ref) for number in (3, 4)
+    )
+    assert rewritten_survivors[0].parents == (merged_trunk_commit,)
+    assert rewritten_survivors[1].parents == (rewritten_survivors[0].commit_id,)
+    assert fake_repo.pull_requests[3].base_ref == "main"
+    assert fake_repo.pull_requests[4].base_ref == fake_repo.pull_requests[3].head_ref
 
 
 def test_sync_reports_a_failed_tracking_removal_in_its_exit_status(


### PR DESCRIPTION
A terminal direct merge already supplies enough evidence to reconcile the
selected local stack. Run the existing selected sync path immediately so
merged changes, rewritten survivors, and tracking converge before merge
returns.

Carry the resolved stack head across the merge so a changed trunk cannot
reinterpret the original selector. Keep queue acceptance asynchronous, and
always distinguish a completed GitHub merge from a later local sync failure
so recovery never repeats the merge.

Describe an enqueued result as current state so an idempotent retry does not
claim to add the pull requests twice. If submit encounters a queued ancestor,
make the whole-stack stop and the unsubmitted suffix recovery explicit.