### PR TITLE
cleanup: preserve merge recovery evidence

### DIFF
--- a/complexity-budget.toml
+++ b/complexity-budget.toml
@@ -13,7 +13,7 @@ governed_c901 = 0
 
 [pytest]
 fixed_property = 8
-merge_recovery = 54
+merge_recovery = 56
 
 [labels]
 production = "Production"

--- a/docs/internals/design.md
+++ b/docs/internals/design.md
@@ -660,12 +660,13 @@ two records.
 A pair is eligible only when:
 
 - GitHub reports the exact saved PR closed or merged
+- for a merged PR, no visible mutable local copy still needs `sync`
 - no other tracked change claims its branch
 - no open PR in the same repository uses the saved head ref as its base
 - no active member of a GitHub stack still needs the branch
 
-Local descendants do not substitute for the open-PR base check. Descendant visibility is evidence
-for `sync`, not deletion of a GitHub branch.
+Local descendants do not substitute for the open-PR base check. A visible mutable copy of merged
+work is evidence for `sync`, not deletion of a GitHub branch or tracking.
 
 Identity and baseline are removed only after artifact cleanup succeeds. A tracking record or PR
 that cannot be inspected is skipped. Once mutation starts, a failure stops cleanup and leaves

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -364,8 +364,9 @@ jj-stack cleanup
 ```
 
 Run `jj-stack sync <head-change-id>` first when merged changes still appear in the local stack.
-Use `cleanup --dry-run` to preview any remaining branch, comment, or tracking removal, then
-run plain `cleanup` to apply the listed actions.
+Cleanup preserves their review branches and tracking so sync can still identify what landed. Use
+`cleanup --dry-run` to preview any remaining branch, comment, or tracking removal, then run plain
+`cleanup` to apply the listed actions.
 
 ## Review bookmarks are visible locally
 

--- a/skills/jj-stack/SKILL.md
+++ b/skills/jj-stack/SKILL.md
@@ -109,7 +109,7 @@ confirms after you explain that risk.
   `cleanup --dry-run <head-change-id>`, then `cleanup <head-change-id>`. For an
   orphan from `list`, use `cleanup --pull-request <pr>`; after the user closes
   every orphan, use `cleanup --pull-request orphans`.
-- **Collect closed or merged leftovers:** `cleanup --dry-run`, then `cleanup`.
+- **Collect closed or already-synced merged leftovers:** `cleanup --dry-run`, then `cleanup`.
   It checks each exact saved PR and removes only verified artifacts for
   closed or merged reviews. Open reviews and open orphans are preserved;
   mismatched or unavailable GitHub state blocks that record.

--- a/src/jj_stack/commands/cleanup/command.py
+++ b/src/jj_stack/commands/cleanup/command.py
@@ -68,7 +68,10 @@ from .shared import (
     _render_cleanup_action_header,
     _render_cleanup_postamble,
 )
-from .stale import LocalCleanupObservation, _local_cleanup_observations
+from .stale import (
+    LocalCleanupObservation,
+    _local_cleanup_observations,
+)
 
 HELP = "Remove review artifacts that are no longer in use"
 
@@ -293,11 +296,13 @@ def _run_local_cleanup_pass(
         local_observation = local_observations.get(
             change_id,
             LocalCleanupObservation(
+                has_mutable_copy=False,
                 stale_reason="local change was not inspected",
             ),
         )
         prepared_change = PreparedCleanupChange(
             change_id=change_id,
+            has_mutable_copy=local_observation.has_mutable_copy,
             review_identity=review_identity,
             stale_reason=local_observation.stale_reason,
             submitted_baseline=submitted_baseline,
@@ -405,14 +410,14 @@ async def _cleanup_tracked_review(
     """Plan and apply one cleanup, returning whether a partial failure must stop the pass."""
 
     identity = prepared_change.review_identity
-    open_review, update, blocker_action = _review_cleanup_update(
+    review_state, update, blocker_action = _review_cleanup_update(
         observation=initial_observation,
         prepared_change=prepared_change,
     )
     if blocker_action is not None:
         record_action(blocker_action)
         return False
-    if open_review:
+    if review_state == "open":
         if prepared_change.stale_reason is not None:
             record_action(
                 CleanupAction(
@@ -421,6 +426,17 @@ async def _cleanup_tracked_review(
                     body=t"preserve open orphan PR #{identity.pr_number}",
                 )
             )
+        return False
+    if review_state == "merged" and prepared_change.has_mutable_copy:
+        record_action(
+            CleanupAction(
+                kind="tracking",
+                status="skipped",
+                body=t"preserve merged PR #{identity.pr_number} for "
+                t"{ui.change_id(prepared_change.change_id)}; run "
+                t"{ui.cmd(f'sync {prepared_change.change_id}')} before cleanup",
+            )
+        )
         return False
     stack_blocker = await github_stack_cleanup_blocker(
         github_client=github_client,
@@ -464,7 +480,7 @@ def _review_cleanup_update(
     *,
     observation: RepositoryObservation,
     prepared_change: PreparedCleanupChange,
-) -> tuple[bool, ReviewRefUpdate | None, CleanupAction | None]:
+) -> tuple[str, ReviewRefUpdate | None, CleanupAction | None]:
     """Check the exact review and derive its remote branch deletion."""
 
     identity = prepared_change.review_identity
@@ -476,11 +492,11 @@ def _review_cleanup_update(
         submitted_baseline=prepared_change.submitted_baseline,
     )
     if blocker is not None:
-        return False, None, _cleanup_action(blocker)
+        return "blocked", None, _cleanup_action(blocker)
     if pull_request is None:
         raise AssertionError("Exact cleanup lookup must return a pull request.")
     if pull_request.state == "open":
-        return True, None, None
+        return "open", None, None
     _pull_request, update, blocker = plan_review_cleanup(
         allowed_states=frozenset({"closed", "merged"}),
         change_id=prepared_change.change_id,
@@ -488,7 +504,7 @@ def _review_cleanup_update(
         review_identity=identity,
         submitted_baseline=prepared_change.submitted_baseline,
     )
-    return False, update, None if blocker is None else _cleanup_action(blocker)
+    return pull_request.state, update, None if blocker is None else _cleanup_action(blocker)
 
 
 async def _preflight_cleanup_overview_comment(

--- a/src/jj_stack/commands/cleanup/shared.py
+++ b/src/jj_stack/commands/cleanup/shared.py
@@ -70,6 +70,7 @@ class PreparedCleanupChange:
     """Locally prepared cleanup state for one complete tracked review."""
 
     change_id: str
+    has_mutable_copy: bool
     review_identity: ReviewIdentity
     stale_reason: str | None
     submitted_baseline: SubmittedBaseline

--- a/src/jj_stack/commands/cleanup/stale.py
+++ b/src/jj_stack/commands/cleanup/stale.py
@@ -12,6 +12,7 @@ from jj_stack.review.repository import observe_repository_paths
 class LocalCleanupObservation:
     """Why one tracked change is stale locally, if it is."""
 
+    has_mutable_copy: bool
     stale_reason: str | None
 
 
@@ -28,11 +29,13 @@ def _local_cleanup_observations(
         revisions = matched_revisions.get(change_id, ())
         if not revisions:
             observations[change_id] = LocalCleanupObservation(
+                has_mutable_copy=False,
                 stale_reason="no visible local change matches that cached change ID",
             )
             continue
         if len(revisions) > 1:
             observations[change_id] = LocalCleanupObservation(
+                has_mutable_copy=any(not revision.immutable for revision in revisions),
                 stale_reason="multiple visible revisions still share that change ID",
             )
             continue
@@ -40,11 +43,13 @@ def _local_cleanup_observations(
         revision = revisions[0]
         if not revision.is_reviewable():
             observations[change_id] = LocalCleanupObservation(
+                has_mutable_copy=not revision.immutable,
                 stale_reason="local change is no longer reviewable",
             )
             continue
 
         observations[change_id] = LocalCleanupObservation(
+            has_mutable_copy=True,
             stale_reason=None,
         )
 
@@ -68,6 +73,7 @@ def _local_cleanup_observations(
     for revision in candidate_revisions:
         if revision.commit_id not in supported_commit_ids:
             observations[revision.change_id] = LocalCleanupObservation(
+                has_mutable_copy=True,
                 stale_reason="local change no longer participates in a supported stack",
             )
     return observations

--- a/tests/integration/test_cleanup_command.py
+++ b/tests/integration/test_cleanup_command.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from jj_stack.errors import CliError
 from jj_stack.github.client import GithubClient, GithubClientError
 from jj_stack.github.overview_comments import STACK_OVERVIEW_COMMENT_MARKER
@@ -23,6 +25,49 @@ from .submit_command_helpers import (
     remote_refs,
     run_main,
 )
+
+
+@pytest.mark.merge_recovery
+@pytest.mark.parametrize("merge_method", ("rebase", "squash"))
+def test_cleanup_preserves_merged_review_until_sync_reconciles_local_copy(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+    merge_method: str,
+) -> None:
+    repo, fake_repo = init_fake_github_repo_with_submitted_feature(tmp_path)
+    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
+    reviewed = selected_stack(repo).head
+    state_store = ReviewStateStore.for_repo(repo)
+    state_before = state_store.load()
+    identity = state_before.review_identities[reviewed.change_id]
+    pull_request = fake_repo.pull_requests[identity.pr_number]
+    if merge_method == "rebase":
+        landed_commit = fake_repo.apply_rebase_merge(pull_request)
+    else:
+        landed_commit = fake_repo.apply_squash_merge(pull_request)
+
+    cleanup_exit_code = run_main(repo, config_path, "cleanup")
+    cleaned = capsys.readouterr()
+
+    assert cleanup_exit_code == 0, (cleaned.out, cleaned.err)
+    assert f"sync {reviewed.change_id}" in " ".join(cleaned.out.split())
+    assert state_store.load() == state_before
+    assert f"refs/heads/{identity.head_ref}" in remote_refs(fake_repo.git_dir)
+
+    sync_exit_code = run_main(repo, config_path, "sync", reviewed.change_id)
+    synced = capsys.readouterr()
+
+    assert sync_exit_code == 0, (synced.out, synced.err)
+    assert reviewed.change_id not in state_store.load().review_identities
+    copies = JjClient(repo).query_revisions_by_change_ids((reviewed.change_id,))[
+        reviewed.change_id
+    ]
+    if merge_method == "rebase":
+        assert tuple(copy.commit_id for copy in copies) == (landed_commit,)
+        assert copies[0].immutable
+    else:
+        assert copies == ()
 
 
 def test_cleanup_removes_closed_review_after_local_change_is_abandoned(

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -76,9 +76,11 @@ def test_local_cleanup_observations_flag_changes_outside_supported_stacks(
     )
 
     assert observations["live-change"] == stale_module.LocalCleanupObservation(
+        has_mutable_copy=True,
         stale_reason=None,
     )
     assert observations["stale-change"] == stale_module.LocalCleanupObservation(
+        has_mutable_copy=True,
         stale_reason="local change no longer participates in a supported stack",
     )
 


### PR DESCRIPTION
A merged pull request can still have a mutable local copy that sync must
reconcile. Removing its branch and tracking during cleanup destroys the
evidence needed for that recovery.

Leave those artifacts intact and name sync while any visible mutable copy
remains. Closed but unmerged reviews retain their existing cleanup path.