### PR TITLE
submit: restart closed reviews

### DIFF
--- a/complexity-budget.toml
+++ b/complexity-budget.toml
@@ -13,7 +13,7 @@ governed_c901 = 0
 
 [pytest]
 fixed_property = 8
-merge_recovery = 56
+merge_recovery = 58
 
 [labels]
 production = "Production"

--- a/docs/internals/design.md
+++ b/docs/internals/design.md
@@ -313,9 +313,10 @@ Two named checks recur throughout the policies:
 Neither check permits mutation alone. Each mutating policy says which other facts must be read
 and when they must be rechecked.
 
-Commands never replace a missing, closed, moved, or ambiguous PR automatically. They leave the
-tracking untouched and direct the user to `relink`, to forget a missing or incorrect link with
-`unstack --local`, or to close and clean up an old review before a fresh `submit`.
+Commands never replace a tracked missing, closed, moved, or ambiguous PR automatically. A merged
+tracked PR directs the user to `sync`; other broken links remain untouched for explicit repair or
+cleanup. Once cleanup removes a closed review's tracking, `submit` ignores historical closed or
+merged PRs for that branch and creates a fresh PR. An open untracked PR still requires `relink`.
 
 Recording a submitted commit cannot replace PR identity: the write fails if the identity changed
 underneath it. A missing or invalid per-change record is isolated and reported with `relink` as

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,8 +105,11 @@ If the change instead shows `remembered PR #<n>`, the PR does still exist. `view
 advisory when it has moved to another head branch, and `jj-stack relink <pr> <change-id>` points
 the change at it.
 
-If GitHub reports a remembered PR as closed or merged, decide what outcome you
-want before choosing a command:
+If GitHub reports a remembered PR as merged, run `jj-stack sync <change-id>` to update the local
+stack and retire tracking for the merged review.
+
+If GitHub reports a remembered PR as closed, decide what outcome you want before choosing a
+command:
 
 - To keep reviewing the same PR, reopen it on GitHub and rerun `jj-stack view <change-id>`.
 - To attach a different open PR to the change, use `jj-stack relink <pr> <change-id>`. That PR

--- a/src/jj_stack/commands/submit/command.py
+++ b/src/jj_stack/commands/submit/command.py
@@ -463,30 +463,14 @@ async def run_submit_async(
         state=state,
         state_store=state_store,
     )
+    tracked_pull_requests = {
+        identity.head_ref: identity.pr_number
+        for prepared in prepared_revisions
+        if (identity := state.review_identities.get(prepared.revision.change_id)) is not None
+    }
     submitted_revisions: tuple[SubmittedRevision, ...] = ()
     async with build_github_client(repository=github_repository) as github_client:
         generated_descriptions = prepared_inputs.generated_pull_request_descriptions
-        drafts: dict[str, bool] | None = None
-        if options.edit:
-            with console.spinner(description="Inspecting current draft states"):
-                editor_pull_requests = await discover_pull_requests_by_branch(
-                    github_client=github_client,
-                    branches=tuple(resolution.branch for resolution in branch_resolutions),
-                )
-            drafts = {
-                prepared.revision.change_id: _desired_draft_state(
-                    draft_mode=options.draft_mode,
-                    pull_request=editor_pull_requests[prepared.branch],
-                )
-                for prepared in prepared_revisions
-            }
-            generated_descriptions, drafts = edit_pull_requests_in_editor(
-                descriptions=generated_descriptions,
-                drafts=drafts,
-                jj_client=client,
-                revisions=stack.revisions,
-            )
-
         with console.spinner(description="Inspecting GitHub"):
             try:
                 (
@@ -498,6 +482,7 @@ async def run_submit_async(
                     discover_pull_requests_by_branch(
                         github_client=github_client,
                         branches=tuple(resolution.branch for resolution in branch_resolutions),
+                        tracked_pull_requests=tracked_pull_requests,
                     ),
                     github_client.list_stacks(),
                 )
@@ -511,14 +496,13 @@ async def run_submit_async(
                 remote=remote,
                 trunk_commit_id=stack.trunk.commit_id,
             )
-        if drafts is None:
-            drafts = {
-                prepared.revision.change_id: _desired_draft_state(
-                    draft_mode=options.draft_mode,
-                    pull_request=discovered_pull_requests[prepared.branch],
-                )
-                for prepared in prepared_revisions
-            }
+        drafts = {
+            prepared.revision.change_id: _desired_draft_state(
+                draft_mode=options.draft_mode,
+                pull_request=discovered_pull_requests[prepared.branch],
+            )
+            for prepared in prepared_revisions
+        }
         pending_syncs = _pending_pull_request_syncs(
             discovered_pull_requests=discovered_pull_requests,
             drafts=drafts,
@@ -532,6 +516,20 @@ async def run_submit_async(
             repository_key=github_repository.repository_key,
             state=mutation_run.state,
         )
+        if options.edit:
+            generated_descriptions, drafts = edit_pull_requests_in_editor(
+                descriptions=generated_descriptions,
+                drafts=drafts,
+                jj_client=client,
+                revisions=stack.revisions,
+            )
+            pending_syncs = _pending_pull_request_syncs(
+                discovered_pull_requests=discovered_pull_requests,
+                drafts=drafts,
+                generated_descriptions=generated_descriptions,
+                prepared_revisions=prepared_revisions,
+                trunk_branch=trunk_branch,
+            )
         pushes_review_branches = any(
             revision.remote_action == "pushed" for revision in prepared_revisions
         )

--- a/src/jj_stack/commands/submit/pull_requests.py
+++ b/src/jj_stack/commands/submit/pull_requests.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 
 import jj_stack.ui as ui
 from jj_stack.concurrency import DEFAULT_BOUNDED_CONCURRENCY, run_bounded_tasks
@@ -25,6 +25,7 @@ async def discover_pull_requests_by_branch(
     *,
     github_client: GithubClient,
     branches: tuple[str, ...],
+    tracked_pull_requests: Mapping[str, int],
 ) -> dict[str, GithubPullRequest | None]:
     if not branches:
         return {}
@@ -40,6 +41,7 @@ async def discover_pull_requests_by_branch(
         branch: _select_discovered_pull_request(
             head_label=f"{github_client.repository.owner}:{branch}",
             pull_requests=discovered_pull_requests.get(branch, ()),
+            tracked_pull_number=tracked_pull_requests.get(branch),
         )
         for branch in branches
     }
@@ -325,8 +327,24 @@ def _select_discovered_pull_request(
     *,
     head_label: str,
     pull_requests: tuple[GithubPullRequest, ...],
+    tracked_pull_number: int | None,
 ) -> GithubPullRequest | None:
-    if len(pull_requests) > 1:
+    open_pull_requests = tuple(
+        pull_request for pull_request in pull_requests if pull_request.state == "open"
+    )
+    tracked_pull_request = next(
+        (
+            pull_request
+            for pull_request in pull_requests
+            if pull_request.number == tracked_pull_number
+        ),
+        None,
+    )
+    if len(open_pull_requests) > 1 or (
+        open_pull_requests
+        and tracked_pull_request is not None
+        and open_pull_requests[0].number != tracked_pull_request.number
+    ):
         raise DriftError(
             t"GitHub reports multiple pull requests for head branch {ui.bookmark(head_label)}.",
             condition="pull_request_ambiguous",
@@ -335,20 +353,7 @@ def _select_discovered_pull_request(
                 t"with {ui.cmd('relink')} before submitting again."
             ),
         )
-    if not pull_requests:
-        return None
-    pull_request = pull_requests[0]
-    if pull_request.state != "open":
-        raise DriftError(
-            t"GitHub reports pull request #{pull_request.number} for head branch "
-            t"{ui.bookmark(head_label)} in state {pull_request.state}.",
-            condition="pull_request_not_open",
-            hint=(
-                t"Inspect the PR link with {ui.cmd('view')} and repair it "
-                t"with {ui.cmd('relink')} before submitting again."
-            ),
-        )
-    return pull_request
+    return tracked_pull_request or (open_pull_requests[0] if open_pull_requests else None)
 
 
 def _ensure_pull_request_link_is_consistent(
@@ -425,6 +430,19 @@ def _ensure_pull_request_link_is_consistent(
             t"saved head owner and branch.",
             condition="saved_pull_request_mismatch",
             hint=t"Inspect it, then repair the intended review with {ui.cmd('relink')}.",
+        )
+    if discovered_pull_request.state != "open":
+        hint = (
+            t"Run {ui.cmd(f'jj-stack sync {change_id}')} to update the local stack."
+            if discovered_pull_request.state == "merged"
+            else t"Reopen the PR, or run {ui.cmd(f'jj-stack cleanup {change_id}')} before "
+            t"starting a new review."
+        )
+        raise DriftError(
+            t"PR #{discovered_pull_request.number} for {ui.change_id(change_id)} is "
+            t"{discovered_pull_request.state} and cannot be updated.",
+            condition="pull_request_not_open",
+            hint=hint,
         )
     if (
         expected_remote_target is None

--- a/tests/integration/test_submit_command.py
+++ b/tests/integration/test_submit_command.py
@@ -1405,6 +1405,59 @@ def test_submit_requires_relink_after_state_loss(
     assert fake_repo.pull_requests[pr_number].title == "feature 1 renamed"
 
 
+@pytest.mark.merge_recovery
+def test_submit_starts_fresh_review_after_closed_review_cleanup(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    repo, fake_repo = init_fake_github_repo_with_submitted_feature(tmp_path)
+    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
+    change_id = selected_stack(repo).head.change_id
+    state_store = ReviewStateStore.for_repo(repo)
+
+    fake_repo.pull_requests[1].state = "closed"
+    assert run_main(repo, config_path, "cleanup", change_id) == 0
+    capsys.readouterr()
+
+    exit_code = run_main(repo, config_path, "submit", change_id)
+    captured = capsys.readouterr()
+    refreshed_identity = state_store.load().review_identities[change_id]
+
+    assert exit_code == 0, (captured.out, captured.err)
+    assert "PR #2" in captured.out
+    assert refreshed_identity.pr_number == 2
+    assert fake_repo.pull_requests[1].state == "closed"
+    assert fake_repo.pull_requests[2].state == "open"
+
+
+@pytest.mark.merge_recovery
+def test_submit_names_sync_when_tracked_review_is_merged(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    repo, fake_repo = init_fake_github_repo_with_submitted_feature(tmp_path)
+    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
+    change_id = selected_stack(repo).head.change_id
+
+    def reject_editor(**_kwargs) -> None:
+        raise AssertionError("submit opened the editor before rejecting the merged PR")
+
+    monkeypatch.setattr(
+        "jj_stack.commands.submit.command.edit_pull_requests_in_editor",
+        reject_editor,
+    )
+
+    fake_repo.apply_squash_merge(fake_repo.pull_requests[1])
+    exit_code = run_main(repo, config_path, "submit", "--edit", change_id)
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert f"jj-stack sync {change_id}" in captured.err
+    assert "relink" not in captured.err
+
+
 def test_submit_fails_closed_when_cached_pull_request_is_missing_on_github(
     tmp_path: Path,
     monkeypatch,

--- a/tests/unit/test_submit.py
+++ b/tests/unit/test_submit.py
@@ -192,25 +192,16 @@ def test_preflight_private_commits_rejects_blocked_revision() -> None:
         preflight_private_commits(PrivateCommitClient(), (private,))
 
 
-@pytest.mark.parametrize(
-    ("states", "message"),
-    (
-        (("open", "open"), "multiple pull requests"),
-        (("closed",), "in state closed"),
-    ),
-)
-def test_discovered_pull_request_must_be_unique_and_open(
-    states: tuple[str, ...],
-    message: str,
-) -> None:
+def test_discovered_pull_request_must_have_only_one_open_review() -> None:
     pull_requests = tuple(
         _github_pull_request(number=number, state=state)
-        for number, state in enumerate(states, start=1)
+        for number, state in enumerate(("open", "open"), start=1)
     )
-    with pytest.raises(CliError, match=message):
+    with pytest.raises(CliError, match="multiple pull requests"):
         _select_discovered_pull_request(
             head_label="octo-org:jj-stack/foo",
             pull_requests=pull_requests,
+            tracked_pull_number=None,
         )
 
 


### PR DESCRIPTION
After cleanup deliberately forgets a closed review, a later submit should
start a fresh pull request instead of rediscovering the historical one by
branch name.

Saved merged or closed links still fail closed with the precise sync,
cleanup, or reopen route. Untracked branch discovery considers only open
pull requests and remains ambiguous when more than one is open.