### PR TITLE
test: explore review lifecycle workflows

### DIFF
--- a/docs/internals/property-testing.md
+++ b/docs/internals/property-testing.md
@@ -38,7 +38,7 @@ testing should spend its budget on those cross-system invariants.
   vocabulary.
 - Make failures reproducible. Every generated scenario must have a stable name and a
   compact operation trace that can be copied into a deterministic regression test.
-- Keep the default suite fast. `./check.py` runs a fixed five-case property corpus; larger
+- Keep the default suite fast. `./check.py` runs a fixed eight-case property corpus; larger
   generated or randomized pools remain opt-in.
 - Use all available workers when exploration is widened. Scenario modules expose generated cases
   as ordinary data so pytest can distribute them across cores.
@@ -167,7 +167,8 @@ unclassified error. Exact diagnostic wording stays out of scope.
 ## Merge and sync coverage
 
 Merge and post-merge convergence use focused deterministic integration tests rather than the
-submit property generator. The tested boundaries include exact submitted-head validation,
+stack-edit generator. A small lifecycle family covers cleanup, restart, and automatic sync;
+expanded runs add rebase cleanup. The deterministic tests cover exact submitted-head validation,
 bottom-prefix selection, draft and closed boundaries, atomic stack-merge failure, partial stack
 merge survivor rewrites, terminal retry, historical-member cleanup, and selected or
 repository-wide sync eligibility.
@@ -237,8 +238,8 @@ For the submitted stack as a whole:
 - fake GitHub recorded no close, merge, or reopen event for any originally submitted PR
 - fake GitHub recorded no base-retarget event for orphaned PRs
 
-The default suite runs five fixed scenarios: one stack edit, one merge, one move, one submit
-retry, and one drift case. Their defined names and counts live in
+The default suite runs eight fixed scenarios: five stack-edit, cross-stack, retry, and drift
+representatives plus three completed-command lifecycle cases. Their names and counts live in
 `tests/support/submit_property_scenarios.py`; larger deterministic pools remain opt-in.
 
 ## Efficiency

--- a/tests/integration/test_cleanup_command.py
+++ b/tests/integration/test_cleanup_command.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from jj_stack.errors import CliError
 from jj_stack.github.client import GithubClient, GithubClientError
 from jj_stack.github.overview_comments import STACK_OVERVIEW_COMMENT_MARKER
@@ -25,49 +23,6 @@ from .submit_command_helpers import (
     remote_refs,
     run_main,
 )
-
-
-@pytest.mark.merge_recovery
-@pytest.mark.parametrize("merge_method", ("rebase", "squash"))
-def test_cleanup_preserves_merged_review_until_sync_reconciles_local_copy(
-    tmp_path: Path,
-    monkeypatch,
-    capsys,
-    merge_method: str,
-) -> None:
-    repo, fake_repo = init_fake_github_repo_with_submitted_feature(tmp_path)
-    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    reviewed = selected_stack(repo).head
-    state_store = ReviewStateStore.for_repo(repo)
-    state_before = state_store.load()
-    identity = state_before.review_identities[reviewed.change_id]
-    pull_request = fake_repo.pull_requests[identity.pr_number]
-    if merge_method == "rebase":
-        landed_commit = fake_repo.apply_rebase_merge(pull_request)
-    else:
-        landed_commit = fake_repo.apply_squash_merge(pull_request)
-
-    cleanup_exit_code = run_main(repo, config_path, "cleanup")
-    cleaned = capsys.readouterr()
-
-    assert cleanup_exit_code == 0, (cleaned.out, cleaned.err)
-    assert f"sync {reviewed.change_id}" in " ".join(cleaned.out.split())
-    assert state_store.load() == state_before
-    assert f"refs/heads/{identity.head_ref}" in remote_refs(fake_repo.git_dir)
-
-    sync_exit_code = run_main(repo, config_path, "sync", reviewed.change_id)
-    synced = capsys.readouterr()
-
-    assert sync_exit_code == 0, (synced.out, synced.err)
-    assert reviewed.change_id not in state_store.load().review_identities
-    copies = JjClient(repo).query_revisions_by_change_ids((reviewed.change_id,))[
-        reviewed.change_id
-    ]
-    if merge_method == "rebase":
-        assert tuple(copy.commit_id for copy in copies) == (landed_commit,)
-        assert copies[0].immutable
-    else:
-        assert copies == ()
 
 
 def test_cleanup_removes_closed_review_after_local_change_is_abandoned(

--- a/tests/integration/test_submit_command.py
+++ b/tests/integration/test_submit_command.py
@@ -1406,32 +1406,6 @@ def test_submit_requires_relink_after_state_loss(
 
 
 @pytest.mark.merge_recovery
-def test_submit_starts_fresh_review_after_closed_review_cleanup(
-    tmp_path: Path,
-    monkeypatch,
-    capsys,
-) -> None:
-    repo, fake_repo = init_fake_github_repo_with_submitted_feature(tmp_path)
-    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    change_id = selected_stack(repo).head.change_id
-    state_store = ReviewStateStore.for_repo(repo)
-
-    fake_repo.pull_requests[1].state = "closed"
-    assert run_main(repo, config_path, "cleanup", change_id) == 0
-    capsys.readouterr()
-
-    exit_code = run_main(repo, config_path, "submit", change_id)
-    captured = capsys.readouterr()
-    refreshed_identity = state_store.load().review_identities[change_id]
-
-    assert exit_code == 0, (captured.out, captured.err)
-    assert "PR #2" in captured.out
-    assert refreshed_identity.pr_number == 2
-    assert fake_repo.pull_requests[1].state == "closed"
-    assert fake_repo.pull_requests[2].state == "open"
-
-
-@pytest.mark.merge_recovery
 def test_submit_names_sync_when_tracked_review_is_merged(
     tmp_path: Path,
     monkeypatch,

--- a/tests/property/test_submit_property_scenarios.py
+++ b/tests/property/test_submit_property_scenarios.py
@@ -15,17 +15,20 @@ from tests.support.integration_helpers import init_fake_github_repo
 from tests.support.submit_property_harness import (
     replay_external_drift_scenario,
     replay_failed_submit_retry_scenario,
+    replay_lifecycle,
     replay_stack_join_scenario,
     replay_stack_move_scenario,
     replay_successful_stack_edit_scenario,
 )
 from tests.support.submit_property_scenarios import (
     ExternalDriftScenario,
+    LifecycleScenario,
     StackEditScenario,
     StackJoinScenario,
     StackMoveScenario,
     SubmitRetryScenario,
     external_drift_scenarios_from_environment,
+    lifecycle_scenarios_from_environment,
     stack_edit_scenarios_from_environment,
     stack_join_scenarios_from_environment,
     stack_move_scenarios_from_environment,
@@ -45,11 +48,23 @@ STACK_JOIN_SCENARIOS = stack_join_scenarios_from_environment()
 STACK_MOVE_SCENARIOS = stack_move_scenarios_from_environment()
 SUBMIT_RETRY_SCENARIOS = submit_retry_scenarios_from_environment()
 EXTERNAL_DRIFT_SCENARIOS = external_drift_scenarios_from_environment()
+LIFECYCLE_SCENARIOS = lifecycle_scenarios_from_environment()
 RETRY_CONFIG_LINES = [
     'labels = ["needs-review"]',
     'reviewers = ["alice"]',
     'team_reviewers = ["platform"]',
 ]
+
+
+@pytest.mark.parametrize("scenario", LIFECYCLE_SCENARIOS, ids=lambda scenario: scenario.name)
+def test_lifecycles(tmp_path, monkeypatch, capsys, scenario: LifecycleScenario) -> None:
+    repo, fake_repo = init_fake_github_repo(tmp_path)
+    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
+
+    def run_cli(args):
+        return run_main(repo, config_path, *args)
+
+    replay_lifecycle(fake_repo, repo, run_cli, capsys.readouterr, scenario)
 
 
 @pytest.mark.parametrize(

--- a/tests/run_submit_property_scenarios.py
+++ b/tests/run_submit_property_scenarios.py
@@ -25,6 +25,7 @@ _REPRODUCTION_SCENARIO_OPTIONS = (
     ),
     ("--retry-scenarios", "JJ_STACK_SUBMIT_PROPERTY_RETRY_SCENARIOS"),
     ("--drift-scenarios", "JJ_STACK_SUBMIT_PROPERTY_DRIFT_SCENARIOS"),
+    ("--lifecycle-scenarios", "JJ_STACK_SUBMIT_PROPERTY_LIFECYCLE_SCENARIOS"),
 )
 
 
@@ -84,6 +85,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--lifecycle-scenarios",
+        type=_non_negative_int,
+        help="Number of completed-command lifecycle scenarios to run (default: all 4).",
+    )
+    parser.add_argument(
         "-n",
         "--jobs",
         default="auto",
@@ -126,6 +132,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     if drift_scenarios is None:
         drift_scenarios = max(20, args.scenarios // 5)
     env["JJ_STACK_SUBMIT_PROPERTY_DRIFT_SCENARIOS"] = str(drift_scenarios)
+    lifecycle_scenarios = args.lifecycle_scenarios
+    env["JJ_STACK_SUBMIT_PROPERTY_LIFECYCLE_SCENARIOS"] = str(
+        4 if lifecycle_scenarios is None else lifecycle_scenarios
+    )
     seed = secrets.randbits(32) if args.random_seed else args.seed
     if seed is None:
         seed = DEFAULT_PROPERTY_SEED

--- a/tests/support/submit_property_harness.py
+++ b/tests/support/submit_property_harness.py
@@ -19,6 +19,7 @@ from .integration_helpers import commit_file, run_command, selected_stack, write
 from .submit_property_scenarios import (
     DriftOperation,
     ExternalDriftScenario,
+    LifecycleScenario,
     StackEditOperation,
     StackEditScenario,
     StackJoinScenario,
@@ -52,6 +53,89 @@ class SubmittedBaseline:
     review_identity: ReviewIdentity
     remote_target: str
     submitted_baseline: StoredBaseline
+
+
+def replay_lifecycle(
+    fake_repo: FakeGithubRepository,
+    repo: Path,
+    run_cli: CliRunner,
+    read_output: OutputDiscarder,
+    scenario: LifecycleScenario,
+) -> None:
+    jj = JjClient(repo)
+    stack_size, merged_prefix = (4, 2) if scenario.template == "direct_merge" else (1, 1)
+    labels = _create_initial_stack(repo, stack_size)
+    assert run_cli(("submit",)) == 0
+    baseline = _capture_submitted_baseline(repo, fake_repo, labels)
+    _approve_initial_pull_requests(fake_repo, baseline)
+    head_id = labels[initial_label(stack_size)]
+    state_store = ReviewStateStore.for_repo(repo)
+    read_output()
+    if scenario.template == "closed_restart":
+        old = baseline["c1"]
+        old_pr = fake_repo.pull_requests[old.pr_number]
+        fake_repo.update_pull_request_state(old_pr, state="closed")
+        assert run_cli(("cleanup", head_id)) == 0
+        assert old.change_id not in state_store.load().review_identities
+        assert f"refs/heads/{old.branch}" not in _remote_refs(fake_repo.git_dir)
+        assert run_cli(("submit", head_id)) == 0
+        fresh = state_store.load().review_identities[old.change_id]
+        assert fresh.pr_number != old.pr_number
+        assert fake_repo.pull_requests[fresh.pr_number].state == "open"
+        assert fake_repo.pull_requests[fresh.pr_number].base_ref == "main"
+        refs = _remote_refs(fake_repo.git_dir)
+        revision = jj.resolve_revision(old.change_id)
+        assert refs[f"refs/heads/{fresh.head_ref}"] == revision.commit_id
+        assert old_pr.state == "closed" and old_pr.merged_at is None
+        _assert_approval_review_preserved(fake_repo, old.pr_number, "c1")
+        assert len(fake_repo.pull_requests) == 2
+        return
+    if scenario.template == "direct_merge":
+        fake_repo.allow_rebase_merge = True
+        assert run_cli(("merge", "--method", "rebase", "--pull-request", "2")) == 0
+        expected_request = (2, "rebase", "direct_merge", baseline["c2"].remote_target)
+        assert fake_repo.stack_merge_requests == [expected_request]
+    else:
+        pull_request = fake_repo.pull_requests[1]
+        fake_repo.apply_pull_request_merge(pull_request, merge_method=scenario.merge_method)
+        state_before, refs_before = state_store.load(), _remote_refs(fake_repo.git_dir)
+        fake_repo.pull_request_events.clear()
+        assert run_cli(("cleanup", head_id)) == 0
+        output = " ".join(" ".join(read_output()).split())
+        assert f"sync {head_id}" in output, output
+        assert state_store.load() == state_before
+        assert _remote_refs(fake_repo.git_dir) == refs_before
+        assert fake_repo.pull_request_events == []
+        assert run_cli(("sync", head_id)) == 0
+    state = state_store.load()
+    refs = _remote_refs(fake_repo.git_dir)
+    for index in range(1, merged_prefix + 1):
+        label = initial_label(index)
+        submitted = baseline[label]
+        assert submitted.change_id not in state.review_identities
+        assert fake_repo.pull_requests[submitted.pr_number].merged_at is not None
+        _assert_approval_review_preserved(fake_repo, submitted.pr_number, label)
+        copies = jj.query_revisions_by_change_ids((submitted.change_id,))[submitted.change_id]
+        if scenario.merge_method == "squash":
+            assert not copies
+        else:
+            assert len(copies) == 1
+            copy = copies[0]
+            assert copy.immutable and not copy.divergent
+            assert copy.commit_id == fake_repo.pull_requests[submitted.pr_number].merge_commit_sha
+    previous_base = "main"
+    for index in range(merged_prefix + 1, stack_size + 1):
+        label = initial_label(index)
+        submitted = baseline[label]
+        assert state.review_identities[submitted.change_id].pr_number == submitted.pr_number
+        assert fake_repo.pull_requests[submitted.pr_number].state == "open"
+        revision = jj.resolve_revision(submitted.change_id)
+        assert refs[f"refs/heads/{submitted.branch}"] == revision.commit_id
+        assert state.submitted_baselines[submitted.change_id].commit_id == revision.commit_id
+        assert fake_repo.pull_requests[submitted.pr_number].base_ref == previous_base
+        _assert_approval_review_preserved(fake_repo, submitted.pr_number, label)
+        previous_base = submitted.branch
+    assert len(fake_repo.pull_requests) == stack_size
 
 
 def _dissolve_github_stacks(

--- a/tests/support/submit_property_scenarios.py
+++ b/tests/support/submit_property_scenarios.py
@@ -33,7 +33,6 @@ SubmitRetryFailurePoint = Literal[
     "update_pull_request",
     "pull_request_metadata",
 ]
-
 DEFAULT_STACK_EDIT_SCENARIO_SEED = 8675309
 MAX_STACK_EDIT_ATTEMPTS_MULTIPLIER = 80
 
@@ -52,6 +51,26 @@ class SubmitInvariants:
     initial_size: int
     orphaned_labels: tuple[str, ...]
     trace: str
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleScenario:
+    name: str
+    template: Literal["cleanup_sync", "closed_restart", "direct_merge"]
+    merge_method: Literal["rebase", "squash"] = "squash"
+
+
+LIFECYCLE_SCENARIOS = (
+    LifecycleScenario("external-squash-cleanup-sync", "cleanup_sync"),
+    LifecycleScenario("closed-single-cleanup-resubmit", "closed_restart"),
+    LifecycleScenario("direct-rebase-two-of-four", "direct_merge", "rebase"),
+    LifecycleScenario("external-rebase-cleanup-sync", "cleanup_sync", "rebase"),
+)
+
+
+def lifecycle_scenarios_from_environment() -> tuple[LifecycleScenario, ...]:
+    count = int(os.environ.get("JJ_STACK_SUBMIT_PROPERTY_LIFECYCLE_SCENARIOS", "3"))
+    return LIFECYCLE_SCENARIOS[:count]
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
Exercise ordinary workflows across cleanup, fresh resubmit, partial direct
merge, and sync. Keep the fixed corpus small and expose the rebase cleanup
counterpart through the expanded runner.

Consolidate overlapping deterministic cases into the shared lifecycle
contract. This makes survivor identity, baselines, topology, and runnable
recovery guidance part of the same end-to-end assertions.