### PR TITLE
docs: reject speculative hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,10 @@ compatibility code, migration code, or the like.
   Do not add a temporary parallel model with a promise to remove it in a later cleanup slice.
 - Define each jj-stack-owned durable policy fact once and store it one way. Shared observation or
   storage code must not create a second path for deciding or changing it.
-- Batch independent read-only facts, but keep dependent mutations in order and re-read their
-  preconditions immediately before changing state.
+- Batch independent read-only facts, but keep dependent mutations in order. Bind an irreversible
+  external mutation to the identity and version observed while planning when the platform
+  supports a conditional write or lease. Re-observe only when an earlier mutation invalidates a
+  precondition or when an observed trigger or platform contract requires it.
 - Apply the cumulative complexity budgets after every code slice. CI runs
   `uv run tools/check_complexity.py`; run it locally when the pinned `tokei` is installed. A
   budget increase is a design stop that requires explicit review, not routine maintenance of the

--- a/docs/internals/code-reviews.md
+++ b/docs/internals/code-reviews.md
@@ -64,9 +64,16 @@ and every fix — including your own proposed fixes:
   or ordering dependency between durable writes requires a spec amendment in the same
   change, plus answers to: what deletes this state, and what happens if that deletion
   never runs? If recovering the new state would need another mechanism, reject it.
-- **Defenses require an observed trigger.** A reproduction, a live-API observation, or a
-  user report. "The other system might do X" earns a backlog entry naming the experiment
-  that would confirm it — never code.
+- **Defenses require an ordinary, observed trigger.** Name the supported command sequence,
+  documented user action, platform behavior, reproduction, or user report that reaches the state.
+  Pathological configurations outside the product contract with no believable ordinary user path,
+  and "the other system might do X," earn neither code nor test budget. At most, record the
+  experiment that would establish a real trigger.
+- **Test real workflows, not imagined instruction schedules.** Protect ordinary sequences of
+  commands and documented external actions. Bind irreversible external mutations to the identity
+  and version observed while planning when the platform supports a conditional write or lease.
+  Re-observe only when an earlier mutation invalidates a precondition or when an observed trigger
+  or platform contract requires it.
 - **Match guard strength to the cost hierarchy.** Name what a proposed guard actually
   protects, against the ranked kernel: lost commits > mutating the wrong PR or ref >
   guessed linkage > metadata consistency. Reconstructible state gets report-and-continue
@@ -165,7 +172,7 @@ Pay extra attention when a change touches:
 - unusual DAG topology or stack-selection edge cases
 - consistency across `jj-stack`, `jj`, GitHub, local persistence, and
   subprocess-visible state
-- interrupted operations or surprising command interleavings
+- interrupted operations or surprising sequences of commands and external actions
 
 In those areas, scrutinize the proposed test coverage closely.
 

--- a/docs/internals/testing-philosophy.md
+++ b/docs/internals/testing-philosophy.md
@@ -35,8 +35,8 @@ coverage or make failures irreproducible.
 ## Bias toward off-happy-path coverage
 
 For this repo, do not assume the happy path is the main risk. Much of the real risk comes from
-broken environments, drift between systems, and stateful operations that interleave in
-surprising ways.
+broken environments, drift between systems, and ordinary but surprising sequences of stateful
+operations.
 
 When reviewing coverage, ask first:
 
@@ -45,8 +45,8 @@ When reviewing coverage, ask first:
 - what happens if `jj-stack`, `jj`, GitHub, local persistence, or subprocess state disagree?
 - what happens if the DAG shape is unusual because of rewrites, relinks, divergence, non-linear
   history, or deleted changes?
-- what happens if an operation is interrupted, retried, or followed by another command before
-  the world is consistent again?
+- what happens when one supported command or documented external action follows another before
+  all systems agree on the result?
 
 Prefer tests that show the tool fails closed, preserves work, and gives the user a recovery
 path.
@@ -58,7 +58,7 @@ Examples of high-value test scenarios:
 - surprising DAG topology or stack selection edge cases
 - interrupted operations and partial cleanup
 - stale, missing, or contradictory tracking state
-- drift or surprising interleaving across `jj-stack`, `jj`, GitHub, and
+- drift or surprising command and external-action sequences across `jj-stack`, `jj`, GitHub, and
   subprocess-visible state
 - recovery paths after a command discovers inconsistent state
 
@@ -69,8 +69,8 @@ worthwhile when the scenario is both plausible and important.
 
 Before adding an off-happy-path test, ask:
 
-- is this state reachable in real use, through supported commands, manual user actions, partial
-  failure, or normal tool drift?
+- is this state reachable in real use through ordinary sequences of supported commands,
+  documented user actions, observed partial failures, or normal tool drift?
 - if it happens, could it lose work, leave cross-system state inconsistent, block recovery, or
   confuse the user badly?
 - do we want a defined safe behavior here, rather than treating it as an internal bug where
@@ -82,6 +82,9 @@ If the answer to those questions is mostly no, do not add the test.
 Examples that usually do not deserve dedicated tests:
 
 - purely imaginary states with no believable path from real usage
+- pathological configurations outside the product contract with no believable ordinary user path;
+  documented rejections still deserve focused coverage when the CLI promises them
+- instruction-level race schedules without an observed trigger or documented platform contract
 - large cross-product matrices where one representative case proves the rule
 - internal corruption cases where the product does not promise graceful recovery and a crash is
   acceptable


### PR DESCRIPTION
Require an ordinary, observed trigger before spending code or test budget on
a defensive path. Protect ordinary sequences of commands and documented
external actions, not imagined instruction schedules or pathological
configurations.

Bind conditional writes and leases to observations made while planning.
Re-observe only when an earlier mutation invalidates a precondition or a real
trigger or platform contract requires it.