### PR TITLE
state: simplify tracking storage

### DIFF
--- a/src/jj_stack/bootstrap.py
+++ b/src/jj_stack/bootstrap.py
@@ -14,7 +14,6 @@ from jj_stack.config import AppConfig, load_config
 from jj_stack.errors import CliError
 from jj_stack.jj.cli_args import JjCliArgs
 from jj_stack.jj.client import JjClient
-from jj_stack.models.review_state import ReviewStateRecordIssue
 from jj_stack.review.branches import (
     install_review_namespace,
 )
@@ -86,32 +85,7 @@ def bootstrap_context(
             repository=repository,
         ),
         repo_root=repo_root,
-        state_store=ReviewStateStore.for_repo(
-            repo_root,
-            issue_reporter=_report_review_state_issues,
-        ),
-    )
-
-
-def _report_review_state_issues(
-    issues: tuple[ReviewStateRecordIssue, ...],
-) -> None:
-    for issue in issues:
-        component = (
-            "pull request details"
-            if issue.record_type == "review_identity"
-            else "last submitted commit"
-        )
-        console.warning(
-            t"Saved {component} for {ui.change_id(issue.change_id)} is unavailable; "
-            t"unrelated reviews will continue."
-        )
-    console.warning(
-        ui.prefixed_line(
-            "Hint: ",
-            t"Run {ui.cmd('jj-stack relink --help')} to replace an unavailable record "
-            t"from its live pull request.",
-        )
+        state_store=ReviewStateStore.for_repo(repo_root),
     )
 
 

--- a/src/jj_stack/commands/_cleanup_actions.py
+++ b/src/jj_stack/commands/_cleanup_actions.py
@@ -91,12 +91,6 @@ def check_tracked_review(
             t"different GitHub repository; point the remote back at it, or reattach the "
             t"change with {ui.cmd('jj-stack relink')}"
         )
-    elif change_id in observation.duplicate_claim_change_ids:
-        reason = (
-            t"cannot inspect saved PR #{pull_request_number} because multiple tracked changes "
-            t"claim its PR number or branch; find them with {ui.cmd('jj-stack list')} and drop "
-            t"the wrong one with {ui.cmd('jj-stack unstack --local')}"
-        )
     elif pull_request is None:
         reason = (
             t"PR #{pull_request_number} is no longer on GitHub; attach a replacement with "

--- a/src/jj_stack/commands/checkout.py
+++ b/src/jj_stack/commands/checkout.py
@@ -125,8 +125,6 @@ def _checkout_saved_stack(
         revision
         for revision in stack.revisions
         if state.review_identities.get(revision.change_id) is None
-        or state.submitted_baselines.get(revision.change_id) is None
-        or state.issues_for(revision.change_id)
     )
     if incomplete:
         raise CliError(
@@ -442,14 +440,6 @@ def _save_checkout_tracking(
     if not changed_count:
         return 0
     context.state_store.relink_reviews(
-        expected={
-            change_id: (
-                state.review_identities.get(change_id),
-                state.submitted_baselines.get(change_id),
-            )
-            for change_id in replacements
-        },
-        expected_issues={change_id: state.issues_for(change_id) for change_id in replacements},
         replacements=replacements,
     )
     return changed_count

--- a/src/jj_stack/commands/cleanup/command.py
+++ b/src/jj_stack/commands/cleanup/command.py
@@ -282,17 +282,7 @@ def _run_local_cleanup_pass(
         review_identity = prepared_cleanup.state.review_identities.get(change_id)
         if review_identity is None:
             continue
-        submitted_baseline = prepared_cleanup.state.submitted_baselines.get(change_id)
-        if submitted_baseline is None:
-            record_action(
-                CleanupAction(
-                    kind="tracking",
-                    status="skipped",
-                    body=t"leave {ui.change_id(change_id)} tracked because its last submitted "
-                    t"commit is unavailable; run {ui.cmd('relink')} to repair PR tracking",
-                )
-            )
-            continue
+        submitted_baseline = prepared_cleanup.state.submitted_baselines[change_id]
         local_observation = local_observations.get(
             change_id,
             LocalCleanupObservation(
@@ -594,8 +584,6 @@ async def _apply_tracked_review_cleanup(
     else:
         prepared_cleanup.context.state_store.retire_review(
             prepared_change.change_id,
-            expected_identity=identity,
-            expected_baseline=baseline,
         )
         record_action(action)
     return False

--- a/src/jj_stack/commands/list_.py
+++ b/src/jj_stack/commands/list_.py
@@ -115,7 +115,6 @@ def _run_list(
     context: CommandContext,
 ) -> int:
     state = context.state_store.load()
-    state_incomplete = bool(state.record_issues)
     if state.review_identities:
         with console.spinner(description="Inspecting local stacks"):
             repository_paths = observe_repository_paths(
@@ -145,10 +144,10 @@ def _run_list(
                     indent=2,
                 )
             )
-            return EXIT_INCOMPLETE if state_incomplete else 0
+            return 0
         if not orphan_rows:
             console.output("No stacks.")
-            return EXIT_INCOMPLETE if state_incomplete else 0
+            return 0
         color_when = context.jj_client.resolve_color_when(
             cli_color=requested_color_mode(),
             stdout_is_tty=sys.stdout.isatty(),
@@ -166,7 +165,7 @@ def _run_list(
             )
         )
         _emit_orphan_hint(orphan_rows)
-        return EXIT_INCOMPLETE if state_incomplete else 0
+        return 0
     github_target = resolve_github_target(context.jj_client.list_git_remotes())
     with console.spinner(description="Inspecting review branches"):
         observed_remote_targets = observe_remote_targets_for_status(
@@ -213,7 +212,7 @@ def _run_list(
                 indent=2,
             )
         )
-        return EXIT_INCOMPLETE if state_incomplete or any(row.incomplete for row in rows) else 0
+        return EXIT_INCOMPLETE if any(row.incomplete for row in rows) else 0
     color_when = context.jj_client.resolve_color_when(
         cli_color=requested_color_mode(),
         stdout_is_tty=sys.stdout.isatty(),
@@ -235,7 +234,7 @@ def _run_list(
     )
     _emit_orphan_hint(orphan_rows)
     _emit_stale_stacks_advisory(discovered=ordered, state=state)
-    return EXIT_INCOMPLETE if state_incomplete or any(row.incomplete for row in rows) else 0
+    return EXIT_INCOMPLETE if any(row.incomplete for row in rows) else 0
 
 
 def _build_orphan_row(orphan: OrphanedRecord) -> OrphanRow:

--- a/src/jj_stack/commands/merge/command.py
+++ b/src/jj_stack/commands/merge/command.py
@@ -152,7 +152,6 @@ def _resolve_merge_target(
 ) -> tuple[str | None, str | None]:
     if pull_request is not None:
         pull_request_number, resolved_revset = resolve_linked_change_for_pull_request(
-            action_name="merge",
             jj_client=context.jj_client,
             pull_request_reference=pull_request,
             revset=revset,
@@ -186,12 +185,6 @@ def _prepare_merge(
         revset=revset,
     )
     prepared = prepared_status.prepared
-    for revision in prepared.stack.revisions:
-        if prepared.state.issues_for(revision.change_id):
-            raise CliError(
-                t"Saved review state for {ui.change_id(revision.change_id)} is malformed.",
-                hint=t"Repair it with {ui.cmd('relink')} before merging the review.",
-            )
     if prepared.remote is None:
         message = prepared.remote_error or t"Could not determine which Git remote to use."
         raise CliError(

--- a/src/jj_stack/commands/merge/preconditions.py
+++ b/src/jj_stack/commands/merge/preconditions.py
@@ -35,10 +35,6 @@ def merge_precondition_error(
         return "GitHub no longer reports the planned repository"
     if github_repository.default_branch not in (None, "", expected_trunk_branch):
         return "GitHub no longer reports the planned trunk branch as its default"
-    if any(
-        revision.change_id in observation.duplicate_claim_change_ids for revision in revisions
-    ):
-        return "multiple saved changes now claim the same pull request or review branch"
     for revision in revisions:
         error = _review_precondition_error(
             expected_bases=expected_bases.get(revision.change_id, ()),

--- a/src/jj_stack/commands/relink.py
+++ b/src/jj_stack/commands/relink.py
@@ -160,17 +160,13 @@ async def _run_relink_async(
         raise CliError(
             t"Remote branch {ui.bookmark(branch)} changed while relink was preparing; retry."
         )
-    state = context.state_store.load()
     _ensure_relinkable_cached_link(
         change_id=revision.change_id,
         identity=identity,
-        state=state,
+        state=context.state_store.load(),
     )
     context.state_store.relink_review(
         revision.change_id,
-        expected_identity=state.review_identities.get(revision.change_id),
-        expected_baseline=state.submitted_baselines.get(revision.change_id),
-        expected_issues=state.issues_for(revision.change_id),
         identity=identity,
         baseline=SubmittedBaseline(commit_id=head_sha),
     )

--- a/src/jj_stack/commands/submit/command.py
+++ b/src/jj_stack/commands/submit/command.py
@@ -66,6 +66,7 @@ from jj_stack.models.review_state import ReviewIdentity
 from jj_stack.models.stack import LocalStack
 from jj_stack.review.branches import (
     ResolvedReviewBranch,
+    ensure_new_review_branches_unclaimed,
     ensure_unique_review_branches,
     review_branch_glob,
     review_branch_matches_change,
@@ -430,6 +431,11 @@ async def run_submit_async(
         remote=remote,
         resolutions=prepared_inputs.branch_resolutions,
         state_identities=state.review_identities,
+    )
+    ensure_new_review_branches_unclaimed(
+        branch_resolutions,
+        state.review_identities,
+        github_repository.repository_key,
     )
     visible_bookmarks = client.visible_review_bookmark_targets()
     collisions = tuple(

--- a/src/jj_stack/commands/submit/inputs.py
+++ b/src/jj_stack/commands/submit/inputs.py
@@ -35,12 +35,6 @@ def prepare_submit_inputs(
         state=state,
     ).stack
     require_reviewable_revisions(stack.revisions)
-    for revision in stack.revisions:
-        if state.issues_for(revision.change_id):
-            raise CliError(
-                t"Saved review state for {ui.change_id(revision.change_id)} is malformed.",
-                hint=t"Repair it with {ui.cmd('relink')} before submitting the review.",
-            )
     branch_resolutions = resolve_review_branches(
         revisions=stack.revisions,
         review_identities=state.review_identities,

--- a/src/jj_stack/commands/submit/models.py
+++ b/src/jj_stack/commands/submit/models.py
@@ -132,23 +132,18 @@ class SubmitMutationRun:
 
         if self.dry_run:
             return
-        expected_identity = self.state.review_identities.get(change_id)
-        expected_baseline = self.state.submitted_baselines.get(change_id)
-        if expected_identity is None and expected_baseline is None:
+        current = self.state.tracked_review(change_id)
+        if current is None:
             self.state = self.state_store.create_review(
                 change_id,
                 identity=identity,
                 baseline=baseline,
             )
             return
-        if expected_identity is None or expected_baseline is None:
-            raise RuntimeError(f"Incomplete review state for {change_id}.")
-        if identity != expected_identity:
+        if identity != current.review_identity:
             raise RuntimeError(f"Review identity changed during submit for {change_id}.")
         self.state = self.state_store.relink_review(
             change_id,
-            expected_identity=expected_identity,
-            expected_baseline=expected_baseline,
             identity=identity,
             baseline=baseline,
         )

--- a/src/jj_stack/commands/submit/pull_requests.py
+++ b/src/jj_stack/commands/submit/pull_requests.py
@@ -9,7 +9,12 @@ from jj_stack.concurrency import DEFAULT_BOUNDED_CONCURRENCY, run_bounded_tasks
 from jj_stack.errors import CliError, DriftError
 from jj_stack.github.client import GithubClient, GithubClientError
 from jj_stack.models.github import GithubPullRequest, GithubPullRequestReview
-from jj_stack.models.review_state import ReviewIdentity, ReviewState, SubmittedBaseline
+from jj_stack.models.review_state import (
+    ReviewIdentity,
+    ReviewState,
+    SubmittedBaseline,
+    TrackedReview,
+)
 
 from .models import (
     PendingPullRequestSync,
@@ -65,8 +70,7 @@ def ensure_pull_request_syncs_are_safe(
     for pending_sync in pending_syncs:
         prepared_revision = pending_sync.prepared
         change_id = prepared_revision.revision.change_id
-        review_identity = state.review_identities.get(change_id)
-        submitted_baseline = state.submitted_baselines.get(change_id)
+        tracked_review = state.tracked_review(change_id)
         pull_request = pending_sync.discovered_pull_request
         if pull_request is not None and pull_request.is_queued:
             head_change_id = pending_syncs[-1].prepared.revision.change_id
@@ -84,12 +88,9 @@ def ensure_pull_request_syncs_are_safe(
             discovered_pull_request=pending_sync.discovered_pull_request,
             expected_remote_target=prepared_revision.expected_remote_target,
             repository_key=repository_key,
-            review_identity=review_identity,
-            submitted_baseline=submitted_baseline,
+            tracked_review=tracked_review,
         )
-        if options.existing_only and (
-            review_identity is None or submitted_baseline is None or pull_request is None
-        ):
+        if options.existing_only and (tracked_review is None or pull_request is None):
             raise CliError(
                 t"Cannot sync {ui.change_id(change_id)} without its existing pull request.",
                 hint=t"Repair the review link with {ui.cmd('relink')} before retrying.",
@@ -363,16 +364,9 @@ def _ensure_pull_request_link_is_consistent(
     discovered_pull_request: GithubPullRequest | None,
     expected_remote_target: str | None,
     repository_key: tuple[str, str],
-    review_identity: ReviewIdentity | None,
-    submitted_baseline: SubmittedBaseline | None,
+    tracked_review: TrackedReview | None,
 ) -> None:
-    if review_identity is None:
-        if submitted_baseline is not None:
-            raise CliError(
-                t"Saved PR tracking for {ui.change_id(change_id)} has a last submitted "
-                t"commit but no pull request number or branch.",
-                hint=t"Repair it with {ui.cmd('relink')} before submitting again.",
-            )
+    if tracked_review is None:
         if discovered_pull_request is not None:
             raise DriftError(
                 t"GitHub already reports PR #{discovered_pull_request.number} for "
@@ -381,11 +375,7 @@ def _ensure_pull_request_link_is_consistent(
                 hint=t"Adopt that PR explicitly with {ui.cmd('relink')} before submitting.",
             )
         return
-    if submitted_baseline is None:
-        raise CliError(
-            t"Saved PR tracking for {ui.change_id(change_id)} has no last submitted commit.",
-            hint=t"Repair it with {ui.cmd('relink')} before submitting again.",
-        )
+    review_identity = tracked_review.review_identity
     if review_identity.repository_key != repository_key:
         raise DriftError(
             t"Saved PR tracking for {ui.change_id(change_id)} belongs to a different GitHub "

--- a/src/jj_stack/commands/submit/revisions.py
+++ b/src/jj_stack/commands/submit/revisions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import jj_stack.ui as ui
-from jj_stack.errors import CliError, DriftError
+from jj_stack.errors import DriftError
 from jj_stack.models.git import GitRemote
 from jj_stack.models.review_state import ReviewState
 from jj_stack.models.stack import LocalStack
@@ -24,17 +24,11 @@ def prepare_submit_revisions(
 
     prepared: list[PreparedSubmitRevision] = []
     for resolution, revision in zip(branch_resolutions, stack.revisions, strict=True):
-        identity = state.review_identities.get(revision.change_id)
-        baseline = state.submitted_baselines.get(revision.change_id)
+        review = state.tracked_review(revision.change_id)
         remote_target = remote_targets.get(resolution.branch)
 
-        if identity is not None:
-            if baseline is None:
-                raise CliError(
-                    t"Saved PR tracking for {ui.change_id(revision.change_id)} has no last "
-                    t"submitted commit.",
-                    hint=t"Repair it with {ui.cmd('relink')} before submitting again.",
-                )
+        if review is not None:
+            identity = review.review_identity
             if identity.head_ref != resolution.branch:
                 raise DriftError(
                     t"Saved PR tracking for {ui.change_id(revision.change_id)} names branch "
@@ -53,7 +47,10 @@ def prepare_submit_revisions(
                         t"{ui.cmd('jj-stack cleanup')}, and submit it again."
                     ),
                 )
-            if remote_target not in {baseline.commit_id, revision.commit_id}:
+            if remote_target not in {
+                review.submitted_baseline.commit_id,
+                revision.commit_id,
+            }:
                 raise DriftError(
                     t"Review branch "
                     t"{ui.bookmark(f'{resolution.branch}@{remote.name}')} points to an "
@@ -64,12 +61,6 @@ def prepare_submit_revisions(
                         t"before submitting again."
                     ),
                 )
-        elif baseline is not None:
-            raise CliError(
-                t"Saved PR tracking for {ui.change_id(revision.change_id)} has a last "
-                t"submitted commit but no pull request identity.",
-                hint=t"Repair it with {ui.cmd('relink')} before submitting again.",
-            )
         elif resolution.recovered_target is not None:
             if remote_target != resolution.recovered_target:
                 raise DriftError(

--- a/src/jj_stack/commands/sync.py
+++ b/src/jj_stack/commands/sync.py
@@ -229,14 +229,7 @@ def _selected_target(
             hint=t"Point jj-stack at a GitHub remote, then rerun. "
             t"{ui.cmd('jj-stack doctor')} reports what it found.",
         )
-    selected = prepared_status.prepared.stack.revisions
-    for revision in selected:
-        if prepared_status.prepared.state.issues_for(revision.change_id):
-            raise CliError(
-                t"Saved review state for {ui.change_id(revision.change_id)} is malformed.",
-                hint=t"Repair it with {ui.cmd('relink')} before syncing this path.",
-            )
-    return target, selected
+    return target, prepared_status.prepared.stack.revisions
 
 
 async def _apply_selected_plan(
@@ -361,13 +354,6 @@ async def _apply_selected_plan(
                 context.jj_client.abandon_revisions(abandoned)
             if github_stack_survivors:
                 context.state_store.relink_reviews(
-                    expected={
-                        survivor.candidate.change_id: (
-                            survivor.candidate.review_identity,
-                            survivor.candidate.submitted_baseline,
-                        )
-                        for survivor in github_stack_survivors
-                    },
                     replacements={
                         survivor.candidate.change_id: (
                             survivor.candidate.review_identity,

--- a/src/jj_stack/commands/sync_global.py
+++ b/src/jj_stack/commands/sync_global.py
@@ -17,7 +17,6 @@ from jj_stack.review.finish import (
     retire_reviews,
 )
 from jj_stack.review.github_stack_sync import observe_github_stacks
-from jj_stack.review.observation import duplicate_review_claim_change_ids
 from jj_stack.review.trunk_evidence import (
     CommitAncestry,
     TrackedReview,
@@ -40,20 +39,8 @@ async def run_global_recovery(*, context: CommandContext, dry_run: bool) -> int:
     )
     trunk = context.jj_client.resolve_revision("trunk()")
     state = context.state_store.load()
-    had_failure = bool(state.record_issues)
-    for issue in state.record_issues:
-        condition = "incomplete" if issue.validation_error.endswith(" is missing.") else "invalid"
-        component = (
-            "pull request details are"
-            if issue.record_type == "review_identity"
-            else "last submitted commit is"
-        )
-        console.warning(
-            t"Skip {ui.change_id(issue.change_id)}: its saved {component} {condition}; "
-            t"repair the tracking with {ui.cmd('relink')}."
-        )
+    had_failure = False
     all_candidates = state.tracked_reviews()
-    duplicate_change_ids = duplicate_review_claim_change_ids(state.review_identities)
     ancestry_by_commit_id = classify_commit_ancestries(
         commit_ids=tuple(candidate.submitted_baseline.commit_id for candidate in all_candidates),
         context=context,
@@ -98,7 +85,6 @@ async def run_global_recovery(*, context: CommandContext, dry_run: bool) -> int:
                     ancestry=ancestry,
                     candidate=candidate,
                     context=context,
-                    duplicate=candidate.change_id in duplicate_change_ids,
                     merge_ancestry=merge_ancestry,
                     pull_request=pull_request,
                     repository=target.repository,
@@ -204,13 +190,10 @@ def _report_global_nonexact_candidate(
     ancestry: CommitAncestry,
     candidate: TrackedReview,
     context: CommandContext,
-    duplicate: bool,
     merge_ancestry: dict[str, CommitAncestry],
     pull_request: GithubPullRequest | GithubClientError | None,
     repository: github_resolution.GithubRepoAddress,
 ) -> bool:
-    if duplicate:
-        return _warn_global_preserved(candidate, "another tracked change claims the same review")
     if not isinstance(pull_request, GithubPullRequest):
         reason = (
             t"could not inspect its current review: {pull_request}"

--- a/src/jj_stack/commands/unstack.py
+++ b/src/jj_stack/commands/unstack.py
@@ -24,7 +24,7 @@ from jj_stack.github.error_messages import github_target_unavailable_messages
 from jj_stack.github.resolution import GithubTarget, resolve_github_target
 from jj_stack.jj.cli_args import JjCliArgs
 from jj_stack.models.github import GithubStack
-from jj_stack.models.review_state import ReviewIdentity, ReviewState, SubmittedBaseline
+from jj_stack.models.review_state import ReviewState
 from jj_stack.review.observation import observe_reviews
 from jj_stack.review.selected import select_review_path
 from jj_stack.review.selection import (
@@ -201,18 +201,11 @@ def _resolve_local_github_stack(
     change_ids: list[str] = []
     pull_numbers: list[int] = []
     for revision in stack.revisions:
-        identity = state.review_identities.get(revision.change_id)
-        baseline = state.submitted_baselines.get(revision.change_id)
-        if identity is None and baseline is None:
+        review = state.tracked_review(revision.change_id)
+        if review is None:
             continue
-        if identity is None or baseline is None:
-            raise CliError(
-                t"Cannot inspect the saved pull request for "
-                t"{ui.change_id(revision.change_id)} because its details are incomplete.",
-                hint=t"Run {ui.cmd('relink')} to repair the saved review before retrying.",
-            )
         change_ids.append(revision.change_id)
-        pull_numbers.append(identity.pr_number)
+        pull_numbers.append(review.review_identity.pr_number)
     return state, tuple(change_ids), tuple(pull_numbers)
 
 
@@ -270,33 +263,22 @@ def _run_local_unstack(
             state=state,
         ).stack
     actions: list[LocalUnstackAction] = []
-    forgotten: list[tuple[str, ReviewIdentity, SubmittedBaseline]] = []
+    forgotten: list[str] = []
     for revision in stack.revisions:
-        review_identity = state.review_identities.get(revision.change_id)
-        submitted_baseline = state.submitted_baselines.get(revision.change_id)
-        if review_identity is None and submitted_baseline is None:
+        review = state.tracked_review(revision.change_id)
+        if review is None:
             continue
-        if review_identity is None or submitted_baseline is None:
-            raise CliError(
-                t"Cannot forget the saved pull request for {ui.change_id(revision.change_id)} "
-                t"because its details are incomplete.",
-                hint=t"Run {ui.cmd('relink')} to repair the saved review before retrying.",
-            )
-        forgotten.append((revision.change_id, review_identity, submitted_baseline))
+        forgotten.append(revision.change_id)
         actions.append(
             LocalUnstackAction(
-                branch=review_identity.head_ref,
+                branch=review.review_identity.head_ref,
                 change_id=revision.change_id,
                 subject=revision.subject,
             )
         )
     if actions and not dry_run:
-        for change_id, review_identity, submitted_baseline in forgotten:
-            context.state_store.retire_review(
-                change_id,
-                expected_identity=review_identity,
-                expected_baseline=submitted_baseline,
-            )
+        for change_id in forgotten:
+            context.state_store.retire_review(change_id)
     return LocalUnstackResult(actions=tuple(actions), dry_run=dry_run)
 
 
@@ -309,7 +291,6 @@ def _resolve_local_revset(
 ) -> str | None:
     if pull_request is not None:
         pull_request_number, resolved_revset = resolve_linked_change_for_pull_request(
-            action_name=action_name,
             jj_client=context.jj_client,
             pull_request_reference=pull_request,
             revset=revset,

--- a/src/jj_stack/commands/view.py
+++ b/src/jj_stack/commands/view.py
@@ -267,7 +267,6 @@ def _resolve_status_selector(
 ) -> _ResolvedViewSelector:
     if selector.kind == "pull_request":
         pull_request_number, resolved_revset = resolve_linked_change_for_pull_request(
-            action_name="view",
             jj_client=context.jj_client,
             pull_request_reference=selector.value,
             revset=None,

--- a/src/jj_stack/models/review_state.py
+++ b/src/jj_stack/models/review_state.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 if TYPE_CHECKING:
     from jj_stack.models.github import GithubPullRequest
-
-ReviewStateRecordType = Literal["review_identity", "submitted_baseline"]
 
 
 class ReviewIdentity(BaseModel):
@@ -52,56 +50,45 @@ class SubmittedBaseline(BaseModel):
     commit_id: str
 
 
-class ReviewStateRecordIssue(BaseModel):
-    """One opaque tracking record that could not be validated independently."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    record_type: ReviewStateRecordType
-    change_id: str
-    fingerprint: str
-    validation_error: str
-
-
 class ReviewState(BaseModel):
-    """Validated tracking records plus non-persisted record diagnostics."""
+    """Validated review tracking records."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     version: Literal[4] = 4
     review_identities: dict[str, ReviewIdentity] = Field(default_factory=dict)
     submitted_baselines: dict[str, SubmittedBaseline] = Field(default_factory=dict)
-    record_issues: tuple[ReviewStateRecordIssue, ...] = Field(
-        default=(),
-        exclude=True,
-        repr=False,
-    )
 
-    def issues_for(self, change_id: str) -> tuple[ReviewStateRecordIssue, ...]:
-        """Return isolated record problems for one exact change ID."""
-
-        return tuple(issue for issue in self.record_issues if issue.change_id == change_id)
+    @model_validator(mode="after")
+    def _require_complete_pairs(self) -> Self:
+        if self.review_identities.keys() != self.submitted_baselines.keys():
+            raise ValueError(
+                "Review identities and submitted baselines must have identical keys."
+            )
+        return self
 
     def tracked_review(self, change_id: str) -> TrackedReview | None:
-        """Return one tracked review, or None when either record is absent."""
+        """Return one tracked review, or None when the change is untracked."""
 
         identity = self.review_identities.get(change_id)
-        baseline = self.submitted_baselines.get(change_id)
-        if identity is None or baseline is None:
+        if identity is None:
             return None
         return TrackedReview(
             change_id=change_id,
             review_identity=identity,
-            submitted_baseline=baseline,
+            submitted_baseline=self.submitted_baselines[change_id],
         )
 
     def tracked_reviews(self) -> tuple[TrackedReview, ...]:
         """Return every tracked review in stable change-ID order."""
 
         return tuple(
-            review
+            TrackedReview(
+                change_id=change_id,
+                review_identity=self.review_identities[change_id],
+                submitted_baseline=self.submitted_baselines[change_id],
+            )
             for change_id in sorted(self.review_identities)
-            if (review := self.tracked_review(change_id)) is not None
         )
 
 

--- a/src/jj_stack/review/branches.py
+++ b/src/jj_stack/review/branches.py
@@ -96,6 +96,31 @@ def resolve_review_branches(
     return resolutions
 
 
+def ensure_new_review_branches_unclaimed(
+    resolutions: tuple[ResolvedReviewBranch, ...],
+    review_identities: Mapping[str, ReviewIdentity],
+    repository_key: tuple[str, str],
+) -> None:
+    saved_by_branch = {
+        identity.head_ref: change_id
+        for change_id, identity in review_identities.items()
+        if identity.repository_key == repository_key
+    }
+    collisions = tuple(
+        resolution.branch
+        for resolution in resolutions
+        if resolution.change_id not in review_identities
+        and resolution.branch in saved_by_branch
+        and saved_by_branch[resolution.branch] != resolution.change_id
+    )
+    if collisions:
+        raise CliError(
+            t"Cannot create a review on saved branch {ui.join(ui.bookmark, collisions)}.",
+            hint=t"Run {ui.cmd('jj-stack list')} to find the change that owns it, then clean "
+            t"up that review or change the new change's subject.",
+        )
+
+
 def ensure_unique_review_branches(
     resolutions: tuple[ResolvedReviewBranch, ...],
 ) -> None:

--- a/src/jj_stack/review/change_status.py
+++ b/src/jj_stack/review/change_status.py
@@ -181,8 +181,7 @@ def submitted_state_disagreement(
             review_identity = state.review_identities.get(revision.change_id)
             if review_identity is None:
                 continue
-            baseline = state.submitted_baselines.get(revision.change_id)
-            if baseline is not None and baseline.commit_id != revision.commit_id:
+            if state.submitted_baselines[revision.change_id].commit_id != revision.commit_id:
                 disagreements.append(revision.change_id)
     return tuple(disagreements)
 

--- a/src/jj_stack/review/convergence.py
+++ b/src/jj_stack/review/convergence.py
@@ -49,20 +49,6 @@ def build_selected_convergence_plan(
 ) -> SelectedConvergencePlan:
     selected = prepared_status.prepared.stack.revisions
     state = prepared_status.prepared.state
-    # Stated once for the whole selection. Enforcing it per change meant two checks that each
-    # missed a population: the evidence path never saw a GitHub-stack survivor, and the survivor
-    # path never saw a change whose work is already on trunk.
-    ambiguous = tuple(
-        revision.change_id
-        for revision in selected
-        if revision.change_id in observation.duplicate_claim_change_ids
-    )
-    if ambiguous:
-        raise CliError(
-            t"Multiple saved changes claim the review for {ui.join(ui.change_id, ambiguous)}.",
-            hint=t"Run {ui.cmd('jj-stack list')} to find them, then drop the wrong one with "
-            t"{ui.cmd('jj-stack unstack --local')}.",
-        )
     stack_history, stack_survivor_reviews = build_selected_github_stack_sync(
         context=context,
         github_stacks=github_stacks,

--- a/src/jj_stack/review/finish.py
+++ b/src/jj_stack/review/finish.py
@@ -200,7 +200,6 @@ async def observe_tracked_review(
     if (
         review.identity != candidate.review_identity
         or review.baseline != candidate.submitted_baseline
-        or candidate.change_id in observation.duplicate_claim_change_ids
     ):
         return None, "saved PR tracking changed while checking the merged PR"
     return observation, None
@@ -241,8 +240,6 @@ async def retire_reviews(
             try:
                 context.state_store.retire_review(
                     candidate.change_id,
-                    expected_identity=candidate.review_identity,
-                    expected_baseline=candidate.submitted_baseline,
                 )
             except (OSError, RuntimeError, ValueError) as error:
                 results[index] = replace(result, retirement_failure=error_message(error))

--- a/src/jj_stack/review/github_stack_sync.py
+++ b/src/jj_stack/review/github_stack_sync.py
@@ -286,7 +286,6 @@ def _validated_member_pull_request(
     if (
         observed is None
         or observed.identity != identity
-        or candidate.change_id in observation.duplicate_claim_change_ids
         or pull_request is None
         or not identity.matches_pull_request(pull_request)
         or pull_request.head.ref != member.head.ref

--- a/src/jj_stack/review/observation.py
+++ b/src/jj_stack/review/observation.py
@@ -35,7 +35,6 @@ class RepositoryObservation:
     """Fresh review facts shared by mutation policies."""
 
     configured_repository: github_resolution.GithubRepoAddress | None
-    duplicate_claim_change_ids: frozenset[str]
     fetched_trunk_commit_id: str | None
     github_repository: GithubRepository | None
     open_pull_requests_by_base: Mapping[str, tuple[GithubPullRequest, ...]] | None
@@ -48,7 +47,7 @@ class RepositoryObservation:
 def duplicate_review_claim_change_ids(
     identities: Mapping[str, ReviewIdentity],
 ) -> frozenset[str]:
-    """Invalidate every change participating in a duplicate PR or head claim."""
+    """Return every change participating in a duplicate PR or head claim."""
 
     values = identities.values()
     pr_claims = Counter((item.repository_key, item.pr_number) for item in values)
@@ -80,9 +79,9 @@ async def observe_reviews(
     store = context.state_store if context is not None else state_store
     assert store is not None
     state = store.load()
-    claim_identities = state.review_identities
     identities = {
-        change_id: claim_identities.get(change_id) for change_id in dict.fromkeys(change_ids)
+        change_id: state.review_identities.get(change_id)
+        for change_id in dict.fromkeys(change_ids)
     }
     repository = github_client.repository
     known_identities = tuple(identity for identity in identities.values() if identity is not None)
@@ -135,7 +134,6 @@ async def observe_reviews(
     fetched_commit = fetched_trunks[0].commit_id if len(fetched_trunks) == 1 else None
     return RepositoryObservation(
         configured_repository=github_resolution.parse_github_repo(remote) if remote else None,
-        duplicate_claim_change_ids=duplicate_review_claim_change_ids(claim_identities),
         fetched_trunk_commit_id=fetched_commit,
         github_repository=github_repository,
         open_pull_requests_by_base=by_base,

--- a/src/jj_stack/review/selection.py
+++ b/src/jj_stack/review/selection.py
@@ -69,10 +69,8 @@ def resolve_orphaned_pull_request(
     live-link path handle it) or when no matching tracked record exists (let
     the live-link path raise its targeted diagnostic).
 
-    Raises `CliError` when two or more tracked records claim the same pull
-    request number. The tracking data is ambiguous; the user must discard an
-    incorrect claim or relink it before `cleanup --pull-request` can act,
-    because there is no single orphan target to clean up.
+    Raises `CliError` when two or more tracked records claim the same pull request number. This
+    can happen when tracking remains from a repository used before the remote was retargeted.
 
     The membership check matches what `list` renders as an `orphan` row: a visible revision
     outside the supported review stacks should still be cleaned up through this path rather than
@@ -94,8 +92,8 @@ def resolve_orphaned_pull_request(
         raise AmbiguousSelectionError(
             t"PR #{pull_request_number} is claimed by multiple tracked records ({rendered}).",
             hint=(
-                t"Discard an incorrect claim with {ui.cmd('unstack --local')} or repair it "
-                t"with {ui.cmd('relink')} before retrying."
+                t"Use the change ID to select the intended review, or point the remote at its "
+                t"repository before retrying."
             ),
         )
     change_id = matching_change_ids[0]
@@ -127,14 +125,12 @@ def resolve_pull_request_number(
 
 def resolve_linked_change_for_pull_request(
     *,
-    action_name: str,
     jj_client: JjClient,
     pull_request_reference: str,
     revset: str | None,
 ) -> tuple[int, str]:
     """Resolve `--pull-request` to one linked visible local change ID."""
 
-    action_label = action_name.capitalize()
     if revset is not None:
         raise UsageError(
             t"Use either {ui.cmd('<revset>')} or {ui.cmd('--pull-request')}, not both."
@@ -160,7 +156,8 @@ def resolve_linked_change_for_pull_request(
     if len(matching_change_ids) > 1:
         raise AmbiguousSelectionError(
             t"PR #{pull_request_number} is linked to multiple local changes.",
-            hint=t"{action_label} by explicit revision after repairing the links.",
+            hint=t"Use an explicit change ID after pointing the remote at the intended "
+            t"repository.",
         )
 
     return pull_request_number, matching_change_ids[0]

--- a/src/jj_stack/review/status.py
+++ b/src/jj_stack/review/status.py
@@ -304,7 +304,6 @@ async def stream_status_async(
     selected_revset = prepared_status.selected_revset
     github_repository = prepared_status.github_repository
     github_repository_error = prepared_status.github_repository_error
-    state_incomplete = bool(prepared.state.record_issues)
     submitted_disagreements = submitted_state_disagreement(
         prepared.state,
         (prepared.stack,),
@@ -347,7 +346,7 @@ async def stream_status_async(
         return StatusResult(
             github_error=None,
             github_repository=github_repository,
-            incomplete=state_incomplete,
+            incomplete=False,
             remote=prepared.remote,
             remote_error=None,
             revisions=(),
@@ -365,7 +364,7 @@ async def stream_status_async(
         return StatusResult(
             github_error=None,
             github_repository=github_repository,
-            incomplete=state_incomplete or _status_is_incomplete(fallback_revisions),
+            incomplete=_status_is_incomplete(fallback_revisions),
             remote=prepared.remote,
             remote_error=None,
             revisions=fallback_revisions,
@@ -409,7 +408,7 @@ async def stream_status_async(
     return StatusResult(
         github_error=None,
         github_repository=github_repository,
-        incomplete=state_incomplete or _status_is_incomplete(display_revisions),
+        incomplete=_status_is_incomplete(display_revisions),
         remote=prepared.remote,
         remote_error=None,
         revisions=display_revisions,

--- a/src/jj_stack/state/store.py
+++ b/src/jj_stack/state/store.py
@@ -7,18 +7,15 @@ import json
 import os
 import shlex
 import tempfile
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Never
 
-from pydantic import BaseModel, ConfigDict, Field, JsonValue, ValidationError
+from pydantic import JsonValue, ValidationError
 
 from jj_stack.errors import CliError
 from jj_stack.models.review_state import (
     ReviewIdentity,
     ReviewState,
-    ReviewStateRecordIssue,
-    ReviewStateRecordType,
     SubmittedBaseline,
 )
 from jj_stack.review.branches import review_branch_matches_change
@@ -26,53 +23,22 @@ from jj_stack.review.branches import review_branch_matches_change
 STATE_DIRNAME = "jj-stack"
 STATE_FILENAME = "state.json"
 
-type ReviewStateIssueReporter = Callable[[tuple[ReviewStateRecordIssue, ...]], None]
-
-_IDENTITY: ReviewStateRecordType = "review_identity"
-_BASELINE: ReviewStateRecordType = "submitted_baseline"
-
 
 class ReviewStateError(CliError):
     """Raised when the tracking data is unreadable or invalid."""
 
 
-class ReviewStateConflictError(ReviewStateError):
-    """Raised when a record changed after a caller observed it."""
-
-
-class _StoredReviewState(BaseModel):
-    """Strict envelope that keeps each record opaque until isolated validation."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    version: int
-    review_identities: dict[str, JsonValue] = Field(default_factory=dict)
-    submitted_baselines: dict[str, JsonValue] = Field(default_factory=dict)
-
-
 class ReviewStateStore:
-    """Load tracking state and atomically compare-and-write review records."""
+    """Load and atomically write review tracking state."""
 
-    def __init__(
-        self,
-        path: Path,
-        *,
-        issue_reporter: ReviewStateIssueReporter | None = None,
-    ) -> None:
+    def __init__(self, path: Path) -> None:
         self._path = path
-        self._issue_reporter = issue_reporter
-        self._reported_issues: set[tuple[ReviewStateRecordType, str, str]] = set()
 
     @classmethod
-    def for_repo(
-        cls,
-        repo_root: Path,
-        *,
-        issue_reporter: ReviewStateIssueReporter | None = None,
-    ) -> ReviewStateStore:
+    def for_repo(cls, repo_root: Path) -> ReviewStateStore:
         """Build a jj-stack data store for the supplied repository root."""
 
-        return cls(resolve_state_path(repo_root), issue_reporter=issue_reporter)
+        return cls(resolve_state_path(repo_root))
 
     def require_writable(self) -> Path:
         """Ensure the data directory can be created and written, then return it."""
@@ -86,9 +52,9 @@ class ReviewStateStore:
         return self._path.parent
 
     def load(self) -> ReviewState:
-        """Load valid records and isolate malformed entries without interpreting them."""
+        """Load and validate the complete tracking file."""
 
-        return self._observe(self._load_envelope())
+        return self._load_state()
 
     def create_review(
         self,
@@ -100,89 +66,53 @@ class ReviewStateStore:
         """Atomically create an identity and baseline when both records are absent."""
 
         _require_identity_matches_change(identity, change_id)
-        envelope = self._load_envelope()
-        if change_id in envelope.review_identities or change_id in envelope.submitted_baselines:
-            self._raise_conflict(change_id, "create review")
-        envelope.review_identities[change_id] = identity.model_dump(mode="json")
-        envelope.submitted_baselines[change_id] = baseline.model_dump(mode="json")
-        return self._persist(envelope)
+        state = self._load_state()
+        if change_id in state.review_identities:
+            raise ReviewStateError(f"Tracking data already exists for {change_id}.")
+        return self._persist(_replace_reviews(state, {change_id: (identity, baseline)}))
 
     def relink_review(
         self,
         change_id: str,
         *,
-        expected_identity: ReviewIdentity | None,
-        expected_baseline: SubmittedBaseline | None,
-        expected_issues: tuple[ReviewStateRecordIssue, ...] = (),
         identity: ReviewIdentity,
         baseline: SubmittedBaseline,
     ) -> ReviewState:
-        """Atomically replace the two records after comparing their prior values."""
+        """Atomically replace one complete review pair."""
 
         return self.relink_reviews(
-            expected={change_id: (expected_identity, expected_baseline)},
-            expected_issues={change_id: expected_issues},
             replacements={change_id: (identity, baseline)},
         )
 
     def relink_reviews(
         self,
         *,
-        expected: Mapping[
-            str,
-            tuple[ReviewIdentity | None, SubmittedBaseline | None],
-        ],
-        expected_issues: Mapping[str, tuple[ReviewStateRecordIssue, ...]] | None = None,
         replacements: Mapping[str, tuple[ReviewIdentity, SubmittedBaseline]],
     ) -> ReviewState:
-        """Atomically replace complete review pairs after comparing every prior value."""
+        """Atomically replace complete review pairs."""
 
-        if expected.keys() != replacements.keys():
-            raise ValueError("Expected and replacement review sets must have identical keys.")
-        envelope = self._load_envelope()
         for change_id, (identity, _baseline) in replacements.items():
             _require_identity_matches_change(identity, change_id)
-            issues = () if expected_issues is None else expected_issues.get(change_id, ())
-            fingerprints = {
-                issue.record_type: issue.fingerprint
-                for issue in issues
-                if issue.change_id == change_id
-            }
-            for expected_record, record_type in zip(
-                expected[change_id], (_IDENTITY, _BASELINE), strict=True
-            ):
-                self._compare_record(
-                    envelope,
-                    change_id,
-                    expected_record,
-                    "relink reviews",
-                    record_type,
-                    fingerprints.get(record_type),
-                )
-        for change_id, (identity, baseline) in replacements.items():
-            envelope.review_identities[change_id] = identity.model_dump(mode="json")
-            envelope.submitted_baselines[change_id] = baseline.model_dump(mode="json")
-        return self._persist(envelope)
+        return self._persist(_replace_reviews(self._load_state(), replacements))
 
     def retire_review(
         self,
         change_id: str,
-        *,
-        expected_identity: ReviewIdentity,
-        expected_baseline: SubmittedBaseline,
     ) -> ReviewState:
-        """Atomically remove one exact identity and baseline pair."""
+        """Atomically remove one complete review pair."""
 
-        envelope = self._load_envelope()
-        self._compare_record(envelope, change_id, expected_identity, "retire review", _IDENTITY)
-        self._compare_record(envelope, change_id, expected_baseline, "retire review", _BASELINE)
-        del envelope.review_identities[change_id]
-        del envelope.submitted_baselines[change_id]
-        return self._persist(envelope)
+        state = self._load_state()
+        identities = dict(state.review_identities)
+        baselines = dict(state.submitted_baselines)
+        del identities[change_id]
+        del baselines[change_id]
+        return self._persist(
+            ReviewState(review_identities=identities, submitted_baselines=baselines)
+        )
 
-    def _load_envelope(self) -> _StoredReviewState:
+    def _load_state(self) -> ReviewState:
         if not self._path.exists():
-            return _StoredReviewState(version=4)
+            return ReviewState()
         if not self._path.is_file():
             raise self._invalid_state_error(f"jj-stack data path is not a file: {self._path}")
         try:
@@ -207,15 +137,18 @@ class ReviewStateStore:
                 f"Invalid jj-stack data in {self._path}: unsupported version {version!r}"
             )
         try:
-            envelope = _StoredReviewState.model_validate(raw)
-        except ValidationError as error:
+            _require_nested_versions(raw)
+            state = ReviewState.model_validate(raw)
+            for change_id, identity in state.review_identities.items():
+                _require_identity_matches_change(identity, change_id)
+        except (ValidationError, ValueError) as error:
             raise self._invalid_state_error(
                 f"Invalid jj-stack data in {self._path}: {error}"
             ) from error
-        return envelope
+        return state
 
-    def _persist(self, envelope: _StoredReviewState) -> ReviewState:
-        rendered = envelope.model_dump_json(exclude_none=True, indent=2) + "\n"
+    def _persist(self, state: ReviewState) -> ReviewState:
+        rendered = state.model_dump_json(exclude_none=True, indent=2) + "\n"
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)
             fd, tmp_name = tempfile.mkstemp(
@@ -234,23 +167,6 @@ class ReviewStateStore:
             raise ReviewStateError(
                 f"Could not write jj-stack data file {self._path}: {error}"
             ) from error
-        return self._observe(envelope)
-
-    def _observe(self, envelope: _StoredReviewState) -> ReviewState:
-        state = _isolate_records(envelope)
-        if self._issue_reporter is None:
-            return state
-        unreported = tuple(
-            issue
-            for issue in state.record_issues
-            if (issue.record_type, issue.change_id, issue.fingerprint)
-            not in self._reported_issues
-        )
-        if unreported:
-            self._issue_reporter(unreported)
-            self._reported_issues.update(
-                (issue.record_type, issue.change_id, issue.fingerprint) for issue in unreported
-            )
         return state
 
     def _invalid_state_error(self, message: str) -> ReviewStateError:
@@ -265,131 +181,30 @@ class ReviewStateStore:
             ),
         )
 
-    def _compare_record(
-        self,
-        envelope: _StoredReviewState,
-        change_id: str,
-        expected: ReviewIdentity | SubmittedBaseline | None,
-        operation: str,
-        record_type: ReviewStateRecordType,
-        invalid_fingerprint: str | None = None,
-    ) -> None:
-        records = (
-            envelope.review_identities
-            if record_type == _IDENTITY
-            else envelope.submitted_baselines
-        )
-        if change_id not in records:
-            if expected is not None:
-                self._raise_conflict(change_id, operation)
-            if invalid_fingerprint is not None and invalid_fingerprint != _record_fingerprint(
-                None,
-                present=False,
-            ):
-                self._raise_conflict(change_id, operation)
-            return
-        record = records.get(change_id)
-        try:
-            current = (
-                _validate_identity(record, change_id)
-                if record_type == _IDENTITY
-                else _validate_baseline(record)
-            )
-        except ValidationError, ValueError:
-            if expected is None and invalid_fingerprint == _record_fingerprint(record):
-                return
-            self._raise_conflict(change_id, operation)
-        if expected is None or current != expected:
-            self._raise_conflict(change_id, operation)
 
-    def _raise_conflict(self, change_id: str, operation: str) -> Never:
-        raise ReviewStateConflictError(
-            f"Tracking data for {change_id} changed before {operation}; reload and retry."
-        )
+def _replace_reviews(
+    state: ReviewState,
+    replacements: Mapping[str, tuple[ReviewIdentity, SubmittedBaseline]],
+) -> ReviewState:
+    identities = dict(state.review_identities)
+    baselines = dict(state.submitted_baselines)
+    for change_id, (identity, baseline) in replacements.items():
+        identities[change_id] = identity
+        baselines[change_id] = baseline
+    return ReviewState(review_identities=identities, submitted_baselines=baselines)
 
 
-def _isolate_records(envelope: _StoredReviewState) -> ReviewState:
-    identities: dict[str, ReviewIdentity] = {}
-    baselines: dict[str, SubmittedBaseline] = {}
-    issues: list[ReviewStateRecordIssue] = []
-    for change_id, record in envelope.review_identities.items():
-        try:
-            identities[change_id] = _validate_identity(record, change_id)
-        except (ValidationError, ValueError) as error:
-            issues.append(
-                _record_issue("review_identity", change_id, record, validation_error=str(error))
-            )
-    for change_id, record in envelope.submitted_baselines.items():
-        try:
-            baselines[change_id] = _validate_baseline(record)
-        except (ValidationError, ValueError) as error:
-            issues.append(
-                _record_issue(
-                    "submitted_baseline",
-                    change_id,
-                    record,
-                    validation_error=str(error),
-                )
-            )
-    for change_id in identities.keys() - envelope.submitted_baselines.keys():
-        issues.append(
-            _record_issue(
-                "submitted_baseline",
-                change_id,
-                None,
-                missing=True,
-                validation_error="Submitted baseline is missing.",
-            )
-        )
-    for change_id in baselines.keys() - envelope.review_identities.keys():
-        issues.append(
-            _record_issue(
-                "review_identity",
-                change_id,
-                None,
-                missing=True,
-                validation_error="Review identity is missing.",
-            )
-        )
-    return ReviewState(
-        review_identities=identities,
-        submitted_baselines=baselines,
-        record_issues=tuple(issues),
-    )
-
-
-def _record_issue(
-    record_type: ReviewStateRecordType,
-    change_id: str,
-    record: JsonValue | None,
-    *,
-    missing: bool = False,
-    validation_error: str,
-) -> ReviewStateRecordIssue:
-    return ReviewStateRecordIssue(
-        record_type=record_type,
-        change_id=change_id,
-        fingerprint=_record_fingerprint(record, present=not missing),
-        validation_error=validation_error,
-    )
-
-
-def _record_fingerprint(record: JsonValue | None, *, present: bool = True) -> str:
-    rendered = json.dumps(
-        [present, record],
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    )
-    return hashlib.sha256(rendered.encode("utf-8")).hexdigest()
-
-
-def _validate_identity(record: JsonValue | None, change_id: str) -> ReviewIdentity:
-    if not isinstance(record, dict) or "version" not in record:
-        raise ValueError("Persisted review identity is missing its version.")
-    identity = ReviewIdentity.model_validate(record)
-    _require_identity_matches_change(identity, change_id)
-    return identity
+def _require_nested_versions(raw: dict[str, JsonValue]) -> None:
+    for field_name, label in (
+        ("review_identities", "review identity"),
+        ("submitted_baselines", "submitted baseline"),
+    ):
+        records = raw.get(field_name)
+        if not isinstance(records, dict):
+            continue
+        for record in records.values():
+            if not isinstance(record, dict) or "version" not in record:
+                raise ValueError(f"Persisted {label} is missing its version.")
 
 
 def _require_identity_matches_change(identity: ReviewIdentity, change_id: str) -> None:
@@ -397,12 +212,6 @@ def _require_identity_matches_change(identity: ReviewIdentity, change_id: str) -
         raise ValueError(
             f"Review branch {identity.head_ref!r} does not match change {change_id!r}."
         )
-
-
-def _validate_baseline(record: JsonValue | None) -> SubmittedBaseline:
-    if not isinstance(record, dict) or "version" not in record:
-        raise ValueError("Persisted submitted baseline is missing its version.")
-    return SubmittedBaseline.model_validate(record)
 
 
 def resolve_state_path(repo_root: Path) -> Path:

--- a/tests/integration/test_cleanup_command.py
+++ b/tests/integration/test_cleanup_command.py
@@ -279,45 +279,6 @@ def test_cleanup_rechecks_open_dependents_before_deleting_branch(
     assert f"refs/heads/{identity.head_ref}" in remote_refs(fake_repo.git_dir)
 
 
-def test_cleanup_blocks_duplicate_saved_pr_claims_before_deleting_artifacts(
-    tmp_path: Path,
-    monkeypatch,
-    capsys,
-) -> None:
-    repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
-    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    stack = selected_stack(repo)
-    bottom_change_id, head_change_id = (revision.change_id for revision in stack.revisions)
-    state_store = ReviewStateStore.for_repo(repo)
-    state = state_store.load()
-    bottom_identity = state.review_identities[bottom_change_id]
-    head_identity = state.review_identities[head_change_id]
-    head_baseline = state.submitted_baselines[head_change_id]
-    state_store.relink_review(
-        head_change_id,
-        expected_identity=head_identity,
-        expected_baseline=head_baseline,
-        identity=head_identity.model_copy(update={"pr_number": bottom_identity.pr_number}),
-        baseline=head_baseline,
-    )
-    ambiguous_state = state_store.load()
-    fake_repo.pull_requests[1].state = "closed"
-    fake_repo.pull_requests[2].state = "closed"
-
-    exit_code = run_main(repo, config_path, "cleanup")
-    captured = capsys.readouterr()
-
-    assert exit_code == 1
-    assert "multiple tracked changes claim its PR number or branch" in " ".join(
-        captured.out.split()
-    )
-    assert "pull request:" in captured.out
-    assert "close:" not in captured.out
-    assert state_store.load() == ambiguous_state
-    for identity in ambiguous_state.review_identities.values():
-        assert f"refs/heads/{identity.head_ref}" in remote_refs(fake_repo.git_dir)
-
-
 def test_cleanup_isolates_malformed_review_observation(
     tmp_path: Path,
     monkeypatch,

--- a/tests/integration/test_list_command.py
+++ b/tests/integration/test_list_command.py
@@ -244,12 +244,7 @@ def test_list_keeps_one_stack_when_saved_tracking_is_sparse_in_the_middle(
     stack = selected_stack(repo)
     middle_change_id = stack.revisions[1].change_id
     state_store = ReviewStateStore.for_repo(repo)
-    state = state_store.load()
-    state_store.retire_review(
-        middle_change_id,
-        expected_identity=state.review_identities[middle_change_id],
-        expected_baseline=state.submitted_baselines[middle_change_id],
-    )
+    state_store.retire_review(middle_change_id)
 
     exit_code = run_main(repo, config_path, "list")
     captured = capsys.readouterr()

--- a/tests/integration/test_relink_command.py
+++ b/tests/integration/test_relink_command.py
@@ -83,8 +83,6 @@ def test_relink_replaces_stale_submitted_commit_with_remote_pr_head(
     baseline = initial_state.submitted_baselines[change_id]
     state_store.relink_review(
         change_id,
-        expected_identity=identity,
-        expected_baseline=baseline,
         identity=identity,
         baseline=baseline.model_copy(update={"commit_id": stale_submitted_commit}),
     )

--- a/tests/integration/test_submit_command.py
+++ b/tests/integration/test_submit_command.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -1459,77 +1458,6 @@ def test_submit_fails_closed_when_cached_pull_request_is_missing_on_github(
     assert state_store.load() == initial_state
     assert read_remote_ref(fake_repo.git_dir, bookmark) == initial_remote_target
     assert fake_repo.pull_requests == {}
-
-
-def test_submit_stops_before_push_when_saved_link_mismatch_has_pending_rewrite(
-    tmp_path: Path,
-    monkeypatch,
-    capsys,
-) -> None:
-    """A damaged PR link must stop `submit` before the rewritten branch is pushed.
-
-    Promoted from the property scenario `rewrite:c2,wrong_saved_pr_number:c2`:
-    the link-consistency check used to run inside the pull-request sync phase,
-    after local bookmarks moved and review branches were force-pushed.
-    """
-
-    repo, fake_repo = init_fake_github_repo_with_submitted_feature(tmp_path)
-    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-
-    stack = selected_stack(repo)
-    change_id = stack.revisions[-1].change_id
-    state_store = ReviewStateStore.for_repo(repo)
-    initial_state = state_store.load()
-    bookmark = initial_state.review_identities[change_id].head_ref
-    initial_remote_target = read_remote_ref(fake_repo.git_dir, bookmark)
-
-    run_command(["jj", "describe", "-r", change_id, "-m", "feature 1 rewritten"], repo)
-    identity = initial_state.review_identities[change_id]
-    baseline = initial_state.submitted_baselines[change_id]
-    state_store.relink_review(
-        change_id,
-        expected_identity=identity,
-        expected_baseline=baseline,
-        identity=identity.model_copy(update={"pr_number": 999_999}),
-        baseline=baseline,
-    )
-    corrupted_state = state_store.load()
-
-    exit_code = run_main(repo, config_path, "submit", change_id)
-    captured = capsys.readouterr()
-
-    assert exit_code == 1
-    assert "Saved pull request #999999 does not match" in captured.err
-    assert state_store.load() == corrupted_state
-    assert read_remote_ref(fake_repo.git_dir, bookmark) == initial_remote_target
-    assert fake_repo.pull_requests[1].title == "feature 1"
-
-
-@pytest.mark.merge_recovery
-def test_submit_rejects_isolated_malformed_identity_before_github_mutation(
-    tmp_path: Path,
-    monkeypatch,
-    capsys,
-) -> None:
-    repo, fake_repo = init_fake_github_repo_with_submitted_feature(tmp_path)
-    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    stack = selected_stack(repo)
-    change_id = stack.revisions[-1].change_id
-    state_path = resolve_state_path(repo)
-    raw_state = json.loads(state_path.read_text(encoding="utf-8"))
-    raw_state["review_identities"][change_id] = {"version": 9}
-    write_file(state_path, json.dumps(raw_state))
-    remote_refs_before = remote_refs(fake_repo.git_dir)
-    fake_repo.pull_request_events.clear()
-
-    exit_code = run_main(repo, config_path, "submit", change_id)
-    captured = capsys.readouterr()
-
-    assert exit_code == 1
-    assert "relink" in captured.err
-    assert remote_refs(fake_repo.git_dir) == remote_refs_before
-    assert fake_repo.pull_request_events == []
-    assert json.loads(state_path.read_text(encoding="utf-8")) == raw_state
 
 
 def test_submit_fails_closed_when_github_reports_multiple_pull_requests(

--- a/tests/integration/test_sync_command.py
+++ b/tests/integration/test_sync_command.py
@@ -19,7 +19,7 @@ from ..support.integration_helpers import (
     selected_stack,
     write_file,
 )
-from ..support.submit_property_harness import advance_remote_trunk, update_remote_ref
+from ..support.submit_property_harness import update_remote_ref
 from .submit_command_helpers import (
     configure_submit_environment,
     read_remote_ref,
@@ -553,7 +553,6 @@ def test_sync_all_requires_terminal_stack_merge_for_exact_stack_member(
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     first, second = selected_stack(repo).revisions
     state_store = ReviewStateStore.for_repo(repo)
-    second_baseline = state_store.load().submitted_baselines[second.change_id]
     fake_repo.github_stacks = {7: (1, 2)}
     fake_repo.auto_merge_reachable_heads = False
     update_remote_ref(fake_repo, branch="main", target=first.commit_id)
@@ -574,35 +573,6 @@ def test_sync_all_requires_terminal_stack_merge_for_exact_stack_member(
     assert "still lists PR #1 as an active member" in " ".join(blocked.err.split())
     assert first.change_id in state_store.load().review_identities
     assert fake_repo.pull_requests[1].state == "open"
-
-    fake_repo.pull_requests[1].state = "closed"
-    fake_repo.pull_requests[1].merged_at = "2026-07-23T12:00:00Z"
-    fake_repo.pull_requests[1].merge_commit_sha = first.commit_id
-    advance_remote_trunk(fake_repo)
-    remote_survivor = fake_repo.rewrite_pull_request_onto_base(
-        fake_repo.pull_requests[2],
-        base_ref="main",
-    )
-    state_path = resolve_state_path(repo)
-    raw_state = json.loads(state_path.read_text(encoding="utf-8"))
-    raw_state["submitted_baselines"].pop(second.change_id)
-    write_file(state_path, json.dumps(raw_state))
-    applied_exit = run_main(repo, config_path, "sync", "--all")
-    applied = capsys.readouterr()
-
-    assert applied_exit == 1
-    assert "still has active members tracked here" in " ".join(applied.err.split())
-    assert first.change_id in state_store.load().review_identities
-
-    raw_state["submitted_baselines"][second.change_id] = second_baseline.model_dump(mode="json")
-    write_file(state_path, json.dumps(raw_state))
-    selected_exit = run_main(repo, config_path, "sync", second.change_id)
-    selected = capsys.readouterr()
-
-    assert selected_exit == 0, (selected.out, selected.err)
-    assert first.change_id not in state_store.load().review_identities
-    assert state_store.load().submitted_baselines[second.change_id].commit_id == remote_survivor
-    assert fake_repo.github_stacks == {7: (1, 2)}
 
 
 def test_sync_does_not_trust_active_stack_head_drift_without_merged_history(

--- a/tests/support/submit_property_harness.py
+++ b/tests/support/submit_property_harness.py
@@ -1057,19 +1057,6 @@ def _apply_drift_operation(
     if drift.kind == "pr_draft_toggled":
         fake_repo.pull_requests[submitted.pr_number].is_draft = True
         return None
-    if drift.kind == "wrong_saved_pr_number":
-        state_store = ReviewStateStore.for_repo(repo)
-        state = state_store.load()
-        identity = state.review_identities[submitted.change_id]
-        stored_baseline = state.submitted_baselines[submitted.change_id]
-        state_store.relink_review(
-            submitted.change_id,
-            expected_identity=identity,
-            expected_baseline=stored_baseline,
-            identity=identity.model_copy(update={"pr_number": 999_999}),
-            baseline=stored_baseline,
-        )
-        return None
     if drift.kind == "remote_branch_drift":
         drift_target = next(
             candidate.remote_target

--- a/tests/support/submit_property_scenarios.py
+++ b/tests/support/submit_property_scenarios.py
@@ -24,7 +24,6 @@ DriftKind = Literal[
     "remote_branch_deleted",
     "remote_branch_drift",
     "trunk_advanced",
-    "wrong_saved_pr_number",
 ]
 DriftOutcome = Literal["fail_closed", "success"]
 SubmitRetryFailurePoint = Literal[
@@ -123,8 +122,8 @@ class DriftKindSpec:
     """Transition metadata for one external-drift kind.
 
     `boundary` names the state-holder the drift mutates: `github_prs` (the PR
-    database), `remote_refs` (the remote Git branch namespace), `tracking_store`
-    (jj-stack's saved beliefs), or `local_jj` (the local DAG and bookmark view).
+    database), `remote_refs` (the remote Git branch namespace), or `local_jj`
+    (the local DAG and bookmark view).
     `expected_outcome` is the model's verdict for a submit issued after the
     drift. Fail-closed kinds carry the contractual `(exit code, diagnosis)`
     pairs the CLI may report: a `DriftError` condition, an
@@ -133,7 +132,7 @@ class DriftKindSpec:
     repair path — from satisfying the model.
     """
 
-    boundary: Literal["github_prs", "local_jj", "remote_refs", "tracking_store"]
+    boundary: Literal["github_prs", "local_jj", "remote_refs"]
     expected_outcome: DriftOutcome
     failures: tuple[tuple[int, str], ...]
     needs_label: bool
@@ -199,12 +198,6 @@ DRIFT_KIND_SPECS: dict[DriftKind, DriftKindSpec] = {
         expected_outcome="success",
         failures=(),
         needs_label=False,
-    ),
-    "wrong_saved_pr_number": DriftKindSpec(
-        boundary="tracking_store",
-        expected_outcome="fail_closed",
-        failures=((1, "saved_pull_request_mismatch"),),
-        needs_label=True,
     ),
 }
 

--- a/tests/unit/test_change_status_topology.py
+++ b/tests/unit/test_change_status_topology.py
@@ -78,14 +78,6 @@ def test_submitted_state_disagreement_flags_rewritten_commit() -> None:
     assert submitted_state_disagreement(state, (stack,)) == ("change-a",)
 
 
-def test_submitted_state_disagreement_skips_records_without_saved_baseline() -> None:
-    a = _revision("change-a")
-    stack = _stack(a)
-    state = ReviewState(review_identities={"change-a": _identity()})
-
-    assert submitted_state_disagreement(state, (stack,)) == ()
-
-
 def _orphan_record(
     *,
     pr_number: int = 42,
@@ -101,7 +93,10 @@ def test_enumerate_orphans_returns_tracked_record_with_open_pr_and_no_live_chang
             "change-live": _identity(pr_number=1),
             "change-orphan": _orphan_record(),
         },
-        submitted_baselines={"change-live": SubmittedBaseline(commit_id="commit-change-live")},
+        submitted_baselines={
+            "change-live": SubmittedBaseline(commit_id="commit-change-live"),
+            "change-orphan": SubmittedBaseline(commit_id="commit-change-orphan"),
+        },
     )
 
     orphans = enumerate_orphaned_records(state, (stack,))
@@ -110,7 +105,12 @@ def test_enumerate_orphans_returns_tracked_record_with_open_pr_and_no_live_chang
 
 
 def test_enumerate_orphaned_records_reports_every_active_record_with_a_pr() -> None:
-    state = ReviewState(review_identities={"change-orphan": _orphan_record()})
+    state = ReviewState(
+        review_identities={"change-orphan": _orphan_record()},
+        submitted_baselines={
+            "change-orphan": SubmittedBaseline(commit_id="commit-change-orphan")
+        },
+    )
 
     orphans = enumerate_orphaned_records(state, ())
 

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -170,7 +170,6 @@ def _observation(
     pull_request = _pull_request()
     return RepositoryObservation(
         configured_repository=_REPOSITORY,
-        duplicate_claim_change_ids=frozenset(),
         fetched_trunk_commit_id=None,
         github_repository=None,
         open_pull_requests_by_base={BRANCH: ()},

--- a/tests/unit/test_merge.py
+++ b/tests/unit/test_merge.py
@@ -146,7 +146,6 @@ def test_merge_preconditions_reject_repository_drift() -> None:
             owner="other",
             repo="widgets",
         ),
-        duplicate_claim_change_ids=frozenset(),
         fetched_trunk_commit_id=None,
         github_repository=_repository(
             allow_merge_commit=False,

--- a/tests/unit/test_relink.py
+++ b/tests/unit/test_relink.py
@@ -12,7 +12,7 @@ from jj_stack.commands.relink import (
 from jj_stack.errors import CliError
 from jj_stack.github.client import GithubClient
 from jj_stack.models.github import GithubBranchRef, GithubPullRequest
-from jj_stack.models.review_state import ReviewIdentity, ReviewState
+from jj_stack.models.review_state import ReviewIdentity, ReviewState, SubmittedBaseline
 
 
 @pytest.mark.parametrize(
@@ -46,7 +46,8 @@ def test_relink_rejects_duplicate_saved_pr_or_branch_claim_in_same_repository() 
     state = ReviewState(
         review_identities={
             "other-change": _identity(pr_number=2),
-        }
+        },
+        submitted_baselines={"other-change": SubmittedBaseline(commit_id="other-commit")},
     )
 
     with pytest.raises(CliError, match="already linked"):

--- a/tests/unit/test_review_branches.py
+++ b/tests/unit/test_review_branches.py
@@ -10,6 +10,7 @@ from jj_stack.models.review_state import ReviewIdentity
 from jj_stack.models.stack import LocalRevision
 from jj_stack.review.branches import (
     ResolvedReviewBranch,
+    ensure_new_review_branches_unclaimed,
     ensure_unique_review_branches,
     generate_review_branch,
     resolve_review_branches,
@@ -87,6 +88,35 @@ def test_review_branch_resolution_rejects_multiple_changes_on_same_branch() -> N
 
     with pytest.raises(CliError, match="multiple changes to the same branch"):
         ensure_unique_review_branches(resolutions)
+
+
+def test_review_branch_resolution_rejects_new_branch_claimed_by_another_stack() -> None:
+    existing_change_id = "abcdefgh-one"
+    new_change_id = "abcdefgh-two"
+    branch = "jj-stack/shared-abcdefgh"
+
+    identities = {existing_change_id: _identity(head_ref=branch)}
+    resolutions = resolve_review_branches(
+        revisions=(_revision(change_id=new_change_id, description="shared"),),
+        review_identities=identities,
+    )
+
+    with pytest.raises(CliError, match="Cannot create a review on saved branch"):
+        ensure_new_review_branches_unclaimed(
+            resolutions,
+            identities,
+            ("octo-org", "stacked-review"),
+        )
+
+    ensure_new_review_branches_unclaimed(
+        resolutions,
+        {
+            existing_change_id: identities[existing_change_id].model_copy(
+                update={"repository_name": "another-repository"}
+            )
+        },
+        ("octo-org", "stacked-review"),
+    )
 
 
 def _identity(*, head_ref: str) -> ReviewIdentity:

--- a/tests/unit/test_review_status.py
+++ b/tests/unit/test_review_status.py
@@ -10,7 +10,7 @@ from jj_stack.github.resolution import GithubRepoAddress, GithubTarget
 from jj_stack.jj.client import JjClient
 from jj_stack.models.git import GitRemote
 from jj_stack.models.github import GithubPullRequest
-from jj_stack.models.review_state import ReviewIdentity, ReviewState
+from jj_stack.models.review_state import ReviewIdentity, ReviewState, SubmittedBaseline
 from jj_stack.models.stack import LocalRevision, LocalStack
 from jj_stack.review import status as status_module
 from jj_stack.review.path import SelectedReviewPath
@@ -82,7 +82,8 @@ def test_prepare_status_observes_only_exact_saved_review_branches(monkeypatch) -
     state = ReviewState(
         review_identities={
             first.change_id: _identity(head_ref="jj-stack/feature-1-aaaaaaaa"),
-        }
+        },
+        submitted_baselines={first.change_id: SubmittedBaseline(commit_id=first.commit_id)},
     )
     client = _PrepareStatusClient(
         _stack_for_status(first, second),
@@ -108,12 +109,14 @@ def test_prepare_status_reloads_saved_branch_after_fetch(monkeypatch) -> None:
         change_id="aaaaaaaa1234",
     )
     stale_state = ReviewState(
-        review_identities={revision.change_id: _identity(head_ref="jj-stack/stale", pr_number=1)}
+        review_identities={revision.change_id: _identity(head_ref="jj-stack/stale", pr_number=1)},
+        submitted_baselines={revision.change_id: SubmittedBaseline(commit_id=revision.commit_id)},
     )
     refreshed_state = ReviewState(
         review_identities={
             revision.change_id: _identity(head_ref="jj-stack/refreshed", pr_number=2)
-        }
+        },
+        submitted_baselines={revision.change_id: SubmittedBaseline(commit_id=revision.commit_id)},
     )
     client = _PrepareStatusClient(
         _stack_for_status(revision),
@@ -146,7 +149,8 @@ def test_stream_status_falls_back_to_local_data_after_github_abort(monkeypatch) 
                 head_ref="jj-stack/feature-1-aaaaaaaa",
                 pr_number=1,
             )
-        }
+        },
+        submitted_baselines={revision.change_id: SubmittedBaseline(commit_id=revision.commit_id)},
     )
     client = _PrepareStatusClient(
         _stack_for_status(revision),

--- a/tests/unit/test_selection.py
+++ b/tests/unit/test_selection.py
@@ -7,7 +7,7 @@ import pytest
 from jj_stack.errors import EXIT_AMBIGUOUS, CliError
 from jj_stack.jj.client import JjClient
 from jj_stack.models.git import GitRemote
-from jj_stack.models.review_state import ReviewIdentity, ReviewState
+from jj_stack.models.review_state import ReviewIdentity, ReviewState, SubmittedBaseline
 from jj_stack.models.stack import LocalRevision
 from jj_stack.review.selection import (
     parse_comma_separated_flag_values,
@@ -40,7 +40,8 @@ def test_resolve_orphaned_pull_request_uses_supported_stack_membership(monkeypat
                 head_ref="jj-stack/change-1",
                 pr_number=17,
             )
-        }
+        },
+        submitted_baselines={"change-1": SubmittedBaseline(commit_id="commit-1")},
     )
     jj_client = _JjClientStub(
         _REPO_ROOT,
@@ -66,25 +67,26 @@ def test_resolve_orphaned_pull_request_uses_supported_stack_membership(monkeypat
     ) == (17, "change-1")
 
 
-def test_resolve_orphaned_pull_request_fails_closed_on_multiple_matches() -> None:
+def test_resolve_orphaned_pull_request_fails_closed_across_repositories() -> None:
+    first = _identity(pr_number=17)
     state = ReviewState(
         review_identities={
-            "change-1": _identity(pr_number=17),
-            "change-2": _identity(pr_number=17),
-        }
+            "change-1": first,
+            "change-2": first.model_copy(update={"repository_name": "previous-repository"}),
+        },
+        submitted_baselines={
+            "change-1": SubmittedBaseline(commit_id="commit-1"),
+            "change-2": SubmittedBaseline(commit_id="commit-2"),
+        },
     )
-    jj_client = _JjClientStub(_REPO_ROOT)
 
-    with pytest.raises(
-        CliError,
-        match=r"PR #17 is claimed by multiple tracked records \(change-1, change-2\)\.",
-    ) as excinfo:
+    with pytest.raises(CliError, match="claimed by multiple tracked records") as excinfo:
         resolve_orphaned_pull_request(
-            jj_client=cast(JjClient, jj_client),
+            jj_client=cast(JjClient, _JjClientStub(_REPO_ROOT)),
             pull_request_reference="17",
             state=state,
         )
-    assert "Discard an incorrect claim with unstack --local" in str(excinfo.value)
+
     assert excinfo.value.exit_code == EXIT_AMBIGUOUS
 
 

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -8,11 +8,7 @@ from pathlib import Path
 import pytest
 
 from jj_stack.models.review_state import ReviewIdentity, ReviewState, SubmittedBaseline
-from jj_stack.state.store import (
-    ReviewStateConflictError,
-    ReviewStateError,
-    ReviewStateStore,
-)
+from jj_stack.state.store import ReviewStateError, ReviewStateStore
 
 CHANGE_ID = "abcdefghijklmno"
 OTHER_CHANGE_ID = "qrstuvwxyzabcde"
@@ -73,8 +69,6 @@ def test_atomic_relink_failure_preserves_original_pair(
     with pytest.raises(ReviewStateError, match="simulated replace failure"):
         store.relink_review(
             CHANGE_ID,
-            expected_identity=identity,
-            expected_baseline=baseline,
             identity=ReviewIdentity(
                 repository_owner=identity.repository_owner,
                 repository_name=identity.repository_name,
@@ -89,223 +83,33 @@ def test_atomic_relink_failure_preserves_original_pair(
     assert not tuple(tmp_path.glob("state.json.*.tmp"))
 
 
-def test_batch_relink_conflict_changes_no_review_pair(tmp_path: Path) -> None:
-    store = ReviewStateStore(tmp_path / "state.json")
-    first_identity = _identity()
-    second_identity = _identity(change_id=OTHER_CHANGE_ID, pr_number=18)
-    old_baseline = SubmittedBaseline(commit_id="old")
-    raced_baseline = SubmittedBaseline(commit_id="raced")
-    store.create_review(CHANGE_ID, identity=first_identity, baseline=old_baseline)
-    store.create_review(OTHER_CHANGE_ID, identity=second_identity, baseline=old_baseline)
-    store.relink_review(
-        OTHER_CHANGE_ID,
-        expected_identity=second_identity,
-        expected_baseline=old_baseline,
-        identity=second_identity,
-        baseline=raced_baseline,
-    )
-
-    with pytest.raises(ReviewStateConflictError):
-        store.relink_reviews(
-            expected={
-                CHANGE_ID: (first_identity, old_baseline),
-                OTHER_CHANGE_ID: (second_identity, old_baseline),
-            },
-            replacements={
-                CHANGE_ID: (_identity(pr_number=19), SubmittedBaseline(commit_id="new-1")),
-                OTHER_CHANGE_ID: (
-                    _identity(change_id=OTHER_CHANGE_ID, pr_number=20),
-                    SubmittedBaseline(commit_id="new-2"),
-                ),
-            },
-        )
-
-    state = store.load()
-    assert state.review_identities[CHANGE_ID] == first_identity
-    assert state.submitted_baselines[CHANGE_ID] == old_baseline
-    assert state.submitted_baselines[OTHER_CHANGE_ID] == raced_baseline
-
-
-def test_stale_expected_identity_cannot_retire_pair(tmp_path: Path) -> None:
-    store = ReviewStateStore(tmp_path / "state.json")
-    identity = _identity()
-    baseline = SubmittedBaseline(commit_id="abc123")
-    original = store.create_review(CHANGE_ID, identity=identity, baseline=baseline)
-
-    with pytest.raises(ReviewStateConflictError, match="reload and retry"):
-        store.retire_review(
-            CHANGE_ID,
-            expected_identity=_identity(pr_number=99),
-            expected_baseline=baseline,
-        )
-
-    assert store.load() == original
-
-
-def test_store_isolates_identity_v1_inside_schema_four(tmp_path: Path) -> None:
-    state_path = tmp_path / "state.json"
-    legacy_identity = _identity().model_dump(mode="json")
-    legacy_identity["version"] = 1
-    state_path.write_text(
-        json.dumps(
-            {
-                "version": 4,
-                "review_identities": {CHANGE_ID: legacy_identity},
-                "submitted_baselines": {
-                    CHANGE_ID: SubmittedBaseline(commit_id="abc123").model_dump(mode="json")
-                },
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    state = ReviewStateStore(state_path).load()
-
-    assert CHANGE_ID not in state.review_identities
-    assert [(issue.record_type, issue.change_id) for issue in state.record_issues] == [
-        ("review_identity", CHANGE_ID)
-    ]
-
-
-def test_store_isolates_identity_with_wrong_branch_suffix(tmp_path: Path) -> None:
-    state_path = tmp_path / "state.json"
-    state_path.write_text(
-        json.dumps(
-            {
-                "version": 4,
-                "review_identities": {
-                    CHANGE_ID: _identity(change_id=OTHER_CHANGE_ID).model_dump(mode="json")
-                },
-                "submitted_baselines": {
-                    CHANGE_ID: SubmittedBaseline(commit_id="abc123").model_dump(mode="json")
-                },
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    state = ReviewStateStore(state_path).load()
-
-    assert CHANGE_ID not in state.review_identities
-    assert state.issues_for(CHANGE_ID)[0].record_type == "review_identity"
-
-
-def test_unrelated_write_preserves_invalid_record_as_opaque_json(tmp_path: Path) -> None:
-    state_path = tmp_path / "state.json"
-    invalid_identity = {"version": 7, "nested": ["do", {"not": "interpret"}]}
-    state_path.write_text(
-        json.dumps(
-            {
-                "version": 4,
-                "review_identities": {
-                    OTHER_CHANGE_ID: invalid_identity,
-                    CHANGE_ID: _identity().model_dump(mode="json"),
-                },
-                "submitted_baselines": {
-                    CHANGE_ID: SubmittedBaseline(commit_id="abc123").model_dump(mode="json")
-                },
-            }
-        ),
-        encoding="utf-8",
-    )
-    store = ReviewStateStore(state_path)
-    loaded = store.load()
-
-    store.relink_review(
-        CHANGE_ID,
-        expected_identity=loaded.review_identities[CHANGE_ID],
-        expected_baseline=loaded.submitted_baselines[CHANGE_ID],
-        identity=loaded.review_identities[CHANGE_ID],
-        baseline=SubmittedBaseline(commit_id="def456"),
-    )
-
-    rendered = json.loads(state_path.read_text(encoding="utf-8"))
-    assert rendered["review_identities"][OTHER_CHANGE_ID] == invalid_identity
-
-
-def test_relink_replaces_only_exact_observed_invalid_record(tmp_path: Path) -> None:
-    state_path = tmp_path / "state.json"
-    state_path.write_text(
-        json.dumps(
-            {
-                "version": 4,
-                "review_identities": {CHANGE_ID: {"version": 9}},
-                "submitted_baselines": {},
-            }
-        ),
-        encoding="utf-8",
-    )
-    store = ReviewStateStore(state_path)
-    observed = store.load()
-    rendered = json.loads(state_path.read_text(encoding="utf-8"))
-    rendered["review_identities"][CHANGE_ID] = {"version": 8}
-    state_path.write_text(json.dumps(rendered), encoding="utf-8")
-
-    with pytest.raises(ReviewStateConflictError):
-        store.relink_review(
-            CHANGE_ID,
-            expected_identity=None,
-            expected_baseline=None,
-            expected_issues=observed.issues_for(CHANGE_ID),
-            identity=_identity(),
-            baseline=SubmittedBaseline(commit_id="abc123"),
-        )
-
-    current = store.load()
-    with pytest.raises(ReviewStateConflictError):
-        store.relink_review(
-            CHANGE_ID,
-            expected_identity=None,
-            expected_baseline=None,
-            expected_issues=tuple(
-                issue.model_copy(update={"change_id": OTHER_CHANGE_ID})
-                for issue in current.issues_for(CHANGE_ID)
-            ),
-            identity=_identity(),
-            baseline=SubmittedBaseline(commit_id="abc123"),
-        )
-    repaired = store.relink_review(
-        CHANGE_ID,
-        expected_identity=None,
-        expected_baseline=None,
-        expected_issues=current.issues_for(CHANGE_ID),
-        identity=_identity(),
-        baseline=SubmittedBaseline(commit_id="abc123"),
-    )
-    assert repaired.review_identities == {CHANGE_ID: _identity()}
-
-
 @pytest.mark.parametrize(
-    ("observed_baselines", "concurrent_baselines"),
-    (({}, {CHANGE_ID: None}), ({CHANGE_ID: None}, {})),
+    "mutate",
+    (
+        lambda state: state["review_identities"][CHANGE_ID].pop("version"),
+        lambda state: state["submitted_baselines"].clear(),
+        lambda state: state["review_identities"].update(
+            {CHANGE_ID: _identity(change_id=OTHER_CHANGE_ID).model_dump(mode="json")}
+        ),
+    ),
 )
-def test_relink_rejects_concurrent_transition_between_missing_and_null(
-    tmp_path: Path,
-    observed_baselines: dict[str, object],
-    concurrent_baselines: dict[str, object],
-) -> None:
+def test_store_rejects_invalid_complete_file(tmp_path: Path, mutate) -> None:
     state_path = tmp_path / "state.json"
-    identity = _identity()
-    payload = {
+    state = {
         "version": 4,
-        "review_identities": {CHANGE_ID: identity.model_dump(mode="json")},
-        "submitted_baselines": observed_baselines,
+        "review_identities": {CHANGE_ID: _identity().model_dump(mode="json")},
+        "submitted_baselines": {
+            CHANGE_ID: SubmittedBaseline(commit_id="abc123").model_dump(mode="json")
+        },
     }
-    state_path.write_text(json.dumps(payload), encoding="utf-8")
-    store = ReviewStateStore(state_path)
-    observed = store.load()
-    payload["submitted_baselines"] = concurrent_baselines
-    state_path.write_text(json.dumps(payload), encoding="utf-8")
+    mutate(state)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
 
-    with pytest.raises(ReviewStateConflictError):
-        store.relink_review(
-            CHANGE_ID,
-            expected_identity=identity,
-            expected_baseline=observed.submitted_baselines.get(CHANGE_ID),
-            expected_issues=observed.issues_for(CHANGE_ID),
-            identity=identity,
-            baseline=SubmittedBaseline(commit_id="abc123"),
-        )
+    with pytest.raises(ReviewStateError, match="Invalid jj-stack data") as caught:
+        ReviewStateStore(state_path).load()
+
+    assert caught.value.hint is not None
+    assert "mv -i" in str(caught.value.hint)
 
 
 def test_store_rejects_schema_two_without_migration(tmp_path: Path) -> None:

--- a/tests/unit/test_submit.py
+++ b/tests/unit/test_submit.py
@@ -35,7 +35,12 @@ from jj_stack.models.github import (
     GithubPullRequestReview,
     GithubPullRequestReviewUser,
 )
-from jj_stack.models.review_state import ReviewState, SubmittedBaseline
+from jj_stack.models.review_state import (
+    ReviewIdentity,
+    ReviewState,
+    SubmittedBaseline,
+    TrackedReview,
+)
 from jj_stack.models.stack import LocalRevision, LocalStack
 from jj_stack.review.branches import ResolvedReviewBranch
 from tests.support.review_state import make_review_identity
@@ -133,8 +138,7 @@ def test_pull_request_link_rejects_missing_discovered_pull_request() -> None:
             discovered_pull_request=None,
             expected_remote_target="commit-17",
             repository_key=("octo-org", "stacked-review"),
-            review_identity=identity,
-            submitted_baseline=SubmittedBaseline(commit_id="commit-17"),
+            tracked_review=_tracked_review(identity),
         )
 
 
@@ -148,8 +152,7 @@ def test_pull_request_link_rejects_a_saved_review_from_another_repository() -> N
             discovered_pull_request=None,
             expected_remote_target="commit-17",
             repository_key=("octo-org", "other-repo"),
-            review_identity=identity,
-            submitted_baseline=SubmittedBaseline(commit_id="commit-17"),
+            tracked_review=_tracked_review(identity),
         )
 
 
@@ -168,9 +171,20 @@ def test_pull_request_link_rejects_remote_and_pr_head_mismatch() -> None:
             discovered_pull_request=pull_request,
             expected_remote_target="remote-commit",
             repository_key=("octo-org", "stacked-review"),
-            review_identity=identity,
-            submitted_baseline=SubmittedBaseline(commit_id="remote-commit"),
+            tracked_review=_tracked_review(identity, commit_id="remote-commit"),
         )
+
+
+def _tracked_review(
+    identity: ReviewIdentity,
+    *,
+    commit_id: str = "commit-17",
+) -> TrackedReview:
+    return TrackedReview(
+        change_id="abcdefghijk",
+        review_identity=identity,
+        submitted_baseline=SubmittedBaseline(commit_id=commit_id),
+    )
 
 
 def test_preflight_private_commits_rejects_blocked_revision() -> None:


### PR DESCRIPTION
Tracking is machine-owned and serialized by the repository operation lock.
Reject an invalid current-format file as a whole instead of preserving
malformed records or comparing against unsupported concurrent edits.

Enforce review ownership when identities are created or adopted, while
retaining ordinary cross-repository ambiguity and partial-failure recovery.