### PR TITLE
merge: remove speculative request rereads

### DIFF
--- a/src/jj_stack/commands/_github_stack_safety.py
+++ b/src/jj_stack/commands/_github_stack_safety.py
@@ -69,6 +69,26 @@ def selected_github_stack(
     return stack
 
 
+async def dissolve_github_stack(
+    *,
+    github_client: GithubClient,
+    stack: GithubStack,
+) -> None:
+    """Dissolve an observed stack and reject an incomplete mutation result."""
+
+    try:
+        remaining = await github_client.unstack(stack_number=stack.number)
+    except GithubClientError as error:
+        raise CliError(t"Could not remove GitHub stack grouping #{stack.number}.") from error
+    if remaining is not None:
+        members = ", ".join(f"#{number}" for number in remaining.pull_request_numbers)
+        raise CliError(
+            t"GitHub stack #{stack.number} still contains {members}.",
+            hint=t"Resolve its locked pull requests, then retry "
+            t"{ui.cmd(f'jj-stack unstack --stack {stack.number}')}.",
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class GithubStackSelection:
     """Live stack membership for one exact ordered PR selection."""
@@ -112,52 +132,3 @@ class GithubStackSelection:
             t"GitHub stack #{stack_number} blocks this jj-stack operation.",
             hint=t"Run {ui.cmd(f'jj-stack unstack --stack {stack_number}')} and retry.",
         )
-
-    async def dissolve_exact(
-        self,
-        *,
-        observed: tuple[GithubStack, ...] | None = None,
-    ) -> GithubStack | None:
-        """Dissolve one exact selected resource before mutating its pull requests."""
-
-        current = await self.recheck_active_suffix(observed=observed)
-        if current is None:
-            return None
-        try:
-            remaining = await self.github_client.unstack(stack_number=current.number)
-        except GithubClientError as error:
-            raise CliError(
-                t"Could not remove GitHub stack grouping #{current.number}."
-            ) from error
-        if remaining is not None:
-            members = ", ".join(f"#{number}" for number in remaining.pull_request_numbers)
-            raise CliError(
-                t"GitHub stack #{current.number} still contains {members}.",
-                hint=t"Resolve its locked pull requests, then retry "
-                t"{ui.cmd(f'jj-stack unstack --stack {current.number}')}.",
-            )
-        return current
-
-    async def recheck_active_suffix(
-        self,
-        *,
-        observed: tuple[GithubStack, ...] | None = None,
-    ) -> GithubStack | None:
-        """Return the current resource after confirming its active membership."""
-
-        stacks = observed if observed is not None else await self.active_stacks()
-        if not stacks:
-            return None
-        stack = selected_github_stack(selected_pull_numbers=self.pull_numbers, stacks=stacks)
-        assert stack is not None
-        try:
-            current = await self.github_client.get_stack(stack_number=stack.number)
-        except GithubClientError as error:
-            raise CliError(t"Could not inspect GitHub stack #{stack.number}.") from error
-        if current.pull_request_numbers != stack.pull_request_numbers:
-            raise CliError(
-                t"GitHub stack #{stack.number} changed before jj-stack could remove its "
-                t"grouping.",
-                hint=t"Retry {ui.cmd(f'jj-stack unstack --stack {stack.number}')}.",
-            )
-        return current

--- a/src/jj_stack/commands/merge/command.py
+++ b/src/jj_stack/commands/merge/command.py
@@ -48,8 +48,8 @@ from jj_stack.state.operation_lock import acquire_operation_lock
 
 from .github_stack import (
     build_async_merge_plan,
-    check_async_merge,
     execute_async_merge,
+    validate_terminal_retry,
 )
 from .models import MergeExecutionInputs, MergeResult, PreparedMerge
 from .plan import build_merge_plan
@@ -292,15 +292,20 @@ async def _stream_merge_async(
             prepared_merge.target_change_id,
         )
         execution = MergeExecutionInputs(
-            context=prepared_merge.context,
             remote_name=remote.name,
             selected_revset=prepared_status.selected_revset,
             trunk_branch=trunk_branch,
             trunk_subject=prepared.stack.trunk.subject,
         )
+        if async_merge.planned and async_merge.terminal_retry:
+            validate_terminal_retry(
+                execution=execution,
+                github=github_client,
+                merge=async_merge,
+                observation=observation,
+            )
         if prepared_merge.dry_run:
             if async_merge.planned:
-                await check_async_merge(execution, github_client, async_merge)
                 action = async_merge.action(
                     merge_action=merge_action,
                     method=resolved_merge_method,

--- a/src/jj_stack/commands/merge/github_stack.py
+++ b/src/jj_stack/commands/merge/github_stack.py
@@ -9,8 +9,8 @@ import jj_stack.ui as ui
 from jj_stack.commands._github_stack_safety import selected_github_stack
 from jj_stack.errors import CliError
 from jj_stack.github.client import GithubClient, GithubClientError
-from jj_stack.models.github import GithubPullRequest, GithubStack, GithubStackMerge
-from jj_stack.review.observation import observe_reviews
+from jj_stack.models.github import GithubStack, GithubStackMerge
+from jj_stack.review.observation import RepositoryObservation
 from jj_stack.ui import Message
 
 from .models import MergeAction, MergeExecutionInputs, MergePlan, MergeResult, MergeRevision
@@ -20,7 +20,6 @@ from .preconditions import merge_precondition_error
 @dataclass(frozen=True, slots=True)
 class AsyncMergePlan:
     resource: GithubStack | None
-    active: tuple[MergeRevision, ...]
     boundary_action: MergeAction | None
     planned: tuple[MergeRevision, ...]
 
@@ -79,11 +78,9 @@ def build_async_merge_plan(
             )
         return AsyncMergePlan(
             resource=None,
-            active=merge_plan.reviewed_revisions,
             boundary_action=merge_plan.boundary_action,
             planned=merge_plan.planned_revisions,
         )
-    active = tuple(by_pull[number] for number in resource.active_pull_request_numbers)
     if merge_plan.planned_revisions:
         planned_numbers = tuple(
             revision.identity.pr_number for revision in merge_plan.planned_revisions
@@ -96,7 +93,6 @@ def build_async_merge_plan(
             )
         return AsyncMergePlan(
             resource,
-            active,
             merge_plan.boundary_action,
             merge_plan.planned_revisions,
         )
@@ -110,8 +106,8 @@ def build_async_merge_plan(
     if target_change_id in change_ids:
         stop = change_ids.index(target_change_id) + 1
     if not stop or merge_plan.reviewed_revisions[: len(historical)] != historical:
-        return AsyncMergePlan(resource, active, merge_plan.boundary_action, ())
-    return AsyncMergePlan(resource, active, None, historical[:stop])
+        return AsyncMergePlan(resource, merge_plan.boundary_action, ())
+    return AsyncMergePlan(resource, None, historical[:stop])
 
 
 async def execute_async_merge(
@@ -126,25 +122,18 @@ async def execute_async_merge(
         return execution.result(
             actions=(() if merge.boundary_action is None else (merge.boundary_action,))
         )
-    pull_request = await check_async_merge(execution, github, merge)
-    if merge.resource is None and pull_request.base.ref != execution.trunk_branch:
+    if merge.resource is None and merge.target.base_ref != execution.trunk_branch:
         try:
             await github.update_pull_request(
-                pull_number=pull_request.number,
+                pull_number=merge.target.identity.pr_number,
                 base=execution.trunk_branch,
             )
         except GithubClientError as error:
             raise CliError(
-                t"Could not retarget PR #{pull_request.number} to "
+                t"Could not retarget PR #{merge.target.identity.pr_number} to "
                 t"{ui.bookmark(execution.trunk_branch)}",
                 hint="Resolve the GitHub error above, then rerun merge.",
             ) from error
-        await check_async_merge(
-            execution,
-            github,
-            merge,
-            expected_bases=(execution.trunk_branch,),
-        )
     try:
         submission = await github.submit_stack_merge(
             expected_head_sha=merge.target.commit_id,
@@ -216,65 +205,30 @@ async def execute_async_merge(
     )
 
 
-async def check_async_merge(
+def validate_terminal_retry(
+    *,
     execution: MergeExecutionInputs,
     github: GithubClient,
     merge: AsyncMergePlan,
-    expected_bases: tuple[str, ...] | None = None,
-) -> GithubPullRequest:
-    resource = (
-        await github.get_stack(stack_number=merge.resource.number)
-        if merge.resource is not None
-        else None
-    )
-    revisions = merge.planned if merge.terminal_retry else merge.active
-    inactive = revisions if merge.terminal_retry else merge.active[len(merge.planned) :]
-    observation = await observe_reviews(
-        change_ids=tuple(revision.change_id for revision in revisions),
-        context=execution.context,
-        github_client=github,
-        remote_name=execution.remote_name,
-        trunk_branch=execution.trunk_branch,
-    )
+    observation: RepositoryObservation,
+) -> None:
+    """Validate a completed server operation from the observation that found it."""
+
+    revisions = merge.planned
     error = merge_precondition_error(
-        inactive_allowed=frozenset(revision.change_id for revision in inactive),
-        expected_bases={
-            revision.change_id: (
-                expected_bases
-                if expected_bases is not None
-                else (
-                    (revision.base_ref, execution.trunk_branch)
-                    if resource is None
-                    else (revision.base_ref,)
-                )
-            )
-            for revision in revisions
-        },
+        inactive_allowed=frozenset(revision.change_id for revision in revisions),
+        expected_bases={},
         expected_repository=github.repository,
         expected_trunk_branch=execution.trunk_branch,
         observation=observation,
         remote_name=execution.remote_name,
         revisions=revisions,
     )
-    stack_changed = (
-        resource is not None
-        and merge.resource is not None
-        and resource.pull_request_numbers != merge.resource.pull_request_numbers
-    )
-    if error or stack_changed:
-        location = (
-            t"GitHub stack #{resource.number}"
-            if resource is not None
-            else t"PR #{merge.target.identity.pr_number}"
-        )
+    if error:
         raise CliError(
-            error or t"{location} changed after planning.",
-            hint=t"Rerun {ui.cmd('jj-stack merge')} to plan against the current stack.",
+            error,
+            hint=t"Resolve the mismatch, then rerun {ui.cmd('jj-stack merge')}.",
         )
-    pull_request = observation.reviews[merge.target.change_id].pull_request
-    if pull_request is None:
-        raise AssertionError("Merge preconditions require the target pull request.")
-    return pull_request
 
 
 async def _terminal(

--- a/src/jj_stack/commands/merge/models.py
+++ b/src/jj_stack/commands/merge/models.py
@@ -55,7 +55,6 @@ class PreparedMerge:
 class MergeExecutionInputs:
     """Mutation dependencies independent of normal stack/status preparation."""
 
-    context: CommandContext
     remote_name: str
     selected_revset: str
     trunk_branch: str

--- a/src/jj_stack/commands/submit/command.py
+++ b/src/jj_stack/commands/submit/command.py
@@ -49,7 +49,7 @@ from pathlib import Path
 import jj_stack.console as console
 import jj_stack.ui as ui
 from jj_stack.bootstrap import CommandContext, bootstrap_context
-from jj_stack.commands._github_stack_safety import GithubStackSelection
+from jj_stack.commands._github_stack_safety import dissolve_github_stack
 from jj_stack.concurrency import DEFAULT_BOUNDED_CONCURRENCY
 from jj_stack.errors import CliError
 from jj_stack.formatting import short_change_id
@@ -587,10 +587,7 @@ async def run_submit_async(
         )
         if github_stack_plan.action == "replace" and not dry_run:
             assert (github_stack := github_stack_plan.affected_stack) is not None
-            await GithubStackSelection(
-                github_client,
-                github_stack.pull_request_numbers,
-            ).dissolve_exact(observed=(github_stack,))
+            await dissolve_github_stack(github_client=github_client, stack=github_stack)
             github_stack_plan = GithubStackPlan("create" if len(pending_syncs) > 1 else "none")
         if not dry_run:
             # GitHub has no transaction spanning review branches, pull requests, and stack

--- a/src/jj_stack/commands/unstack.py
+++ b/src/jj_stack/commands/unstack.py
@@ -17,7 +17,11 @@ import jj_stack.console as console
 import jj_stack.ui as ui
 from jj_stack.bootstrap import CommandContext, bootstrap_context
 from jj_stack.commands._cleanup_actions import check_tracked_review
-from jj_stack.commands._github_stack_safety import GithubStackSelection
+from jj_stack.commands._github_stack_safety import (
+    GithubStackSelection,
+    dissolve_github_stack,
+    selected_github_stack,
+)
 from jj_stack.errors import CliError, UsageError
 from jj_stack.github.client import GithubClient, GithubClientError, build_github_client
 from jj_stack.github.error_messages import github_target_unavailable_messages
@@ -127,11 +131,6 @@ async def _run_github_unstack(
             if github_stack is None:
                 console.output(t"No GitHub stack grouping #{stack_number} was found.")
                 return 0
-            selection = GithubStackSelection(
-                github_client,
-                github_stack.pull_request_numbers,
-            )
-            observed = (github_stack,)
         else:
             state, change_ids, pull_numbers = _resolve_local_github_stack(
                 context=context,
@@ -150,12 +149,13 @@ async def _run_github_unstack(
             )
             selection = GithubStackSelection(github_client, pull_numbers)
             observed = await selection.active_stacks()
+            github_stack = selected_github_stack(
+                selected_pull_numbers=pull_numbers,
+                stacks=observed,
+            )
 
-        github_stack = (
-            await selection.recheck_active_suffix(observed=observed)
-            if dry_run
-            else await selection.dissolve_exact(observed=observed)
-        )
+        if github_stack is not None and not dry_run:
+            await dissolve_github_stack(github_client=github_client, stack=github_stack)
 
     if github_stack is None:
         console.output("No GitHub stack grouping was found for the selected pull requests.")

--- a/tests/integration/test_merge_command.py
+++ b/tests/integration/test_merge_command.py
@@ -309,48 +309,6 @@ def test_stack_merge_terminal_failure_is_atomic(
     assert state_store.load() == state_before
 
 
-@pytest.mark.parametrize("dry_run", (False, True))
-def test_stack_merge_reobserves_lower_heads_before_request(
-    tmp_path: Path,
-    monkeypatch,
-    capsys,
-    dry_run: bool,
-) -> None:
-    repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
-    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    fake_repo.auto_merge_reachable_heads = False
-    fake_repo.github_stacks = {7: (1, 2)}
-    trunk_before = read_remote_ref(fake_repo.git_dir, "main")
-    app = create_app(FakeGithubState.single_repository(fake_repo))
-
-    class LowerHeadRaceClient(GithubClient):
-        async def get_stack(self, *, stack_number):
-            stack = await super().get_stack(stack_number=stack_number)
-            update_remote_ref(
-                fake_repo,
-                branch=fake_repo.pull_requests[1].head_ref,
-                target=trunk_before,
-            )
-            return stack
-
-    patch_github_client_builders(
-        monkeypatch,
-        app=app,
-        fake_repo=fake_repo,
-        modules=("jj_stack.commands.merge.command",),
-        client_type=LowerHeadRaceClient,
-    )
-
-    exit_code = run_main(repo, config_path, "merge", *(("--dry-run",) if dry_run else ()))
-    captured = capsys.readouterr()
-
-    assert exit_code == 1
-    assert "last submitted commit" in captured.err
-    assert fake_repo.stack_merge_requests == []
-    assert tuple(pr.state for pr in fake_repo.pull_requests.values()) == ("open", "open")
-    assert read_remote_ref(fake_repo.git_dir, "main") == trunk_before
-
-
 def test_stack_merge_recovers_only_from_a_terminal_retry(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
Bind merge requests to the initially validated plan with GitHub's expected-head check. Preserve terminal retry by validating historical members from that same observation, and dissolve the exact observed GitHub stack without a second non-atomic membership lookup.