### PR TITLE
adoption: trust one validated review snapshot

### DIFF
--- a/docs/internals/backlog.md
+++ b/docs/internals/backlog.md
@@ -71,27 +71,6 @@ corresponding failures prove important._
 - draft-state and review-rerequest failures
 - retry after an external GitHub change between attempts
 
-## Checkout import guard covers only the selected pull request
-
-_Benefit: medium — closes the remaining case where `checkout --fetch` can leave a divergent copy
-behind, but needs a decision about when the pull-request chain is read._
-
-`checkout --fetch --pull-request` now reads the selected PR head's change ID before importing and
-stops when a visible local revision already holds that change at another commit. The check covers
-the selected head only. Reproduced remaining case: on a two-PR stack, rewrite the bottom change
-and then abandon the top change. The selected head's change is no longer visible locally, so the
-guard returns early, the import proceeds, and the bottom change ends up permanently divergent with
-every rerun failing identically.
-
-Rewriting a change also rewrites its descendants, so the ordinary rewrite-since-submit case is
-already caught: the selected head's commit differs too. Reaching the gap needs the selected
-change absent or hidden while a lower one survives in rewritten form.
-
-Covering every head means reading the pull-request chain before the import. That walk currently
-runs after it, and only the chain read that follows the import is used for the tracking write. A
-pre-import walk would therefore either duplicate those requests or move the required read
-earlier. Decide which before implementing.
-
 ## `sync` strands a review branch that `cleanup` can no longer remove
 
 _Benefit: medium — leaves branches in the reserved namespace with no supported way to delete

--- a/docs/internals/design.md
+++ b/docs/internals/design.md
@@ -664,10 +664,11 @@ a rerun.
 ### Adoption and repair
 
 `checkout` adopts review state already on GitHub and never rewrites commits, restacks descendants,
-moves the workspace, or mutates PRs. Before `--fetch` imports anything, it reads the PR head's
-change ID from the remote object without creating a ref. If a visible local revision already has
-that change ID at another commit, it stops and names `relink`; importing would create a divergent
-copy that rerunning could not remove. Temporary refs and bookmarks are removed before return.
+moves the workspace, or mutates PRs. Before `--fetch` imports anything, it reads each PR head's
+change ID from the remote objects without creating refs. If a visible local revision already has
+one of those change IDs at another commit, it stops and names `relink`; importing would create a
+divergent copy that rerunning could not remove. Temporary refs and bookmarks are removed before
+return.
 
 `relink` explicitly replaces uncertain tracking for one change. It verifies the known PR and
 same-repository head branch, then saves the identity and exact observed remote target as one pair.

--- a/src/jj_stack/commands/checkout.py
+++ b/src/jj_stack/commands/checkout.py
@@ -142,6 +142,7 @@ async def _checkout_pull_request_stack(
     pull_request_reference: str,
 ) -> CheckoutResult:
     client = context.jj_client
+    state = context.state_store.load()
     remote = select_submit_remote(client.list_git_remotes())
     repository = require_github_repo(remote)
     pull_number = parse_repository_pull_request_reference(
@@ -171,16 +172,22 @@ async def _checkout_pull_request_stack(
                 t"PR #{pull_number} and remote branch "
                 t"{ui.bookmark(top_pull_request.head.ref)} no longer identify the same commit."
             )
+        pull_requests = await _load_pull_request_chain(
+            github_client=github_client,
+            repository=repository,
+            top=top_pull_request,
+        )
 
         if fetch:
+            for pull_request in reversed(pull_requests):
+                _reject_locally_rewritten_change(
+                    client=client,
+                    head_sha=_require_pull_request_head_sha(pull_request),
+                    pull_number=pull_request.number,
+                    remote_name=remote.name,
+                )
             client.fetch_remote(
                 remote=remote.name,
-            )
-            _reject_locally_rewritten_change(
-                client=client,
-                head_sha=top_head_sha,
-                pull_number=pull_number,
-                remote_name=remote.name,
             )
             with client.import_remote_review_ref(
                 remote=remote.name,
@@ -194,7 +201,7 @@ async def _checkout_pull_request_stack(
                 stack = _discover_checkout_stack(
                     client=client,
                     revision=imported.commit_id,
-                    state=context.state_store.load(),
+                    state=state,
                 )
         else:
             matches = client.query_revisions_by_commit_ids((top_head_sha,))
@@ -210,33 +217,16 @@ async def _checkout_pull_request_stack(
             stack = _discover_checkout_stack(
                 client=client,
                 revision=top_head_sha,
-                state=context.state_store.load(),
+                state=state,
             )
 
-        # Only the chain read after this re-read is used for the tracking write below.
-        fresh_top = await _load_pull_request(
-            github_client=github_client,
-            pull_number=pull_number,
-        )
-        _validate_same_repository_managed_pull_request(
-            pull_request=fresh_top,
-            repository=repository,
-        )
-        await _require_unique_pull_request_head(
-            github_client=github_client,
-            pull_request=fresh_top,
-        )
-        pull_requests = await _load_pull_request_chain(
-            github_client=github_client,
-            repository=repository,
-            top=fresh_top,
-        )
         adopted_count = _save_checkout_tracking(
             context=context,
             pull_requests=pull_requests,
             remote_name=remote.name,
             repository=repository,
             stack=stack,
+            state=state,
         )
     return CheckoutResult(
         adopted_count=adopted_count,
@@ -385,6 +375,7 @@ def _save_checkout_tracking(
     remote_name: str,
     repository: GithubRepoAddress,
     stack: LocalStack,
+    state: ReviewState,
 ) -> int:
     pull_request_heads = tuple(
         _require_pull_request_head_sha(pull_request) for pull_request in pull_requests
@@ -424,7 +415,6 @@ def _save_checkout_tracking(
             ),
             SubmittedBaseline(commit_id=head_sha),
         )
-    state = context.state_store.load()
     _reject_duplicate_checkout_claims(
         current=state.review_identities,
         replacements={change_id: pair[0] for change_id, pair in replacements.items()},

--- a/src/jj_stack/commands/relink.py
+++ b/src/jj_stack/commands/relink.py
@@ -72,6 +72,7 @@ async def _run_relink_async(
     revset: str | None,
 ) -> RelinkResult:
     client = context.jj_client
+    state = context.state_store.load()
     selected = resolve_selected_revset(
         command_label="relink",
         require_explicit=True,
@@ -80,7 +81,7 @@ async def _run_relink_async(
     stack = select_review_path(
         jj_client=client,
         revset=selected,
-        state=context.state_store.load(),
+        state=state,
     ).stack
     require_reviewable_revisions(stack.revisions)
     if not stack.revisions:
@@ -141,29 +142,7 @@ async def _run_relink_async(
     _ensure_relinkable_cached_link(
         change_id=revision.change_id,
         identity=identity,
-        state=context.state_store.load(),
-    )
-    async with build_github_client(repository=repository) as github_client:
-        fresh_pull_request, fresh_head_sha = await _load_exact_relink_pull_request(
-            change_id=revision.change_id,
-            github_client=github_client,
-            pull_number=pull_number,
-            repository_owner=repository.owner,
-        )
-    if (fresh_pull_request.head.ref, fresh_head_sha) != (branch, head_sha):
-        raise CliError(t"Pull request #{pull_number} changed while relink was preparing; retry.")
-    fresh_remote_target = client.list_remote_branches(
-        remote=remote.name,
-        patterns=(f"refs/heads/{branch}",),
-    ).get(branch)
-    if fresh_remote_target != head_sha:
-        raise CliError(
-            t"Remote branch {ui.bookmark(branch)} changed while relink was preparing; retry."
-        )
-    _ensure_relinkable_cached_link(
-        change_id=revision.change_id,
-        identity=identity,
-        state=context.state_store.load(),
+        state=state,
     )
     context.state_store.relink_review(
         revision.change_id,

--- a/tests/integration/test_checkout_command.py
+++ b/tests/integration/test_checkout_command.py
@@ -86,6 +86,36 @@ def test_checkout_fetch_rejects_a_locally_rewritten_pull_request_without_importi
     assert len(JjClient(repo).query_revisions(f"change_id({change_id})")) == 1
 
 
+def test_checkout_fetch_rejects_a_rewritten_lower_pull_request(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=2)
+    config_path = _configure_checkout_environment(monkeypatch, tmp_path, fake_repo)
+    stack = selected_stack(repo)
+    bottom_change_id = stack.revisions[0].change_id
+    fake_repo.force_push_pull_request_head(fake_repo.pull_requests[1])
+    resolve_state_path(repo).unlink()
+    run_command(["jj", "abandon", stack.head.change_id], repo)
+    run_command(
+        [
+            "git",
+            "config",
+            "--replace-all",
+            "remote.origin.fetch",
+            "+refs/heads/*:refs/remotes/origin/*",
+        ],
+        repo,
+    )
+    capsys.readouterr()
+
+    assert _main(repo, config_path, "checkout", "--fetch", "--pull-request", "2") == 1
+
+    assert "fetching it would leave two copies" in " ".join(capsys.readouterr().err.split())
+    assert len(JjClient(repo).query_revisions(f"change_id({bottom_change_id})")) == 1
+
+
 def test_checkout_pull_request_rejects_cross_repository_head(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
Checkout and relink already establish pull request identity, ownership,
and exact remote targets before changing local state. Reuse that evidence,
and guard every checkout member before an ordinary fetch can import a
rewritten review branch.