### PR TITLE
sync: act on planned convergence evidence

### DIFF
--- a/src/jj_stack/commands/merge/command.py
+++ b/src/jj_stack/commands/merge/command.py
@@ -264,7 +264,6 @@ async def _stream_merge_async(
                 context=prepared_merge.context,
                 github_client=github_client,
                 remote_name=remote.name,
-                trunk_branch=trunk_branch,
             )
         except GithubClientError as error:
             raise CliError(

--- a/src/jj_stack/commands/sync.py
+++ b/src/jj_stack/commands/sync.py
@@ -17,9 +17,9 @@ Some local states stop `sync` before it rebases:
 - An unreviewed change sits between reviewed changes. `sync` updates existing pull requests but
   never creates the missing review.
 
-Before rebasing, `sync` also checks the configured remote, fetched trunk, saved pull request
-links, and GitHub stack membership. A missing, moved, closed, or ambiguous review stops the run
-before local history changes. The message names the state to inspect or repair.
+Before rebasing, `sync` also checks saved pull request links and GitHub stack membership. A
+missing, moved, closed, or ambiguous review stops the run before local history changes. The
+message names the state to inspect or repair.
 
 Conflicts do not prevent the local rebase. If a rebased review remains conflicted, `sync` leaves
 the conflict in local history and stops before updating that pull request. Resolve the conflict
@@ -57,6 +57,7 @@ from jj_stack.github.client import GithubClient, build_github_client
 from jj_stack.github.resolution import GithubTarget, resolve_trunk_branch
 from jj_stack.jj.cli_args import JjCliArgs
 from jj_stack.jj.client import UnsupportedStackError
+from jj_stack.models.github import GithubPullRequest
 from jj_stack.models.review_state import SubmittedBaseline
 from jj_stack.models.stack import LocalRevision
 from jj_stack.review.convergence import (
@@ -72,10 +73,7 @@ from jj_stack.review.finish import (
     retire_reviews,
 )
 from jj_stack.review.github_stack_sync import resolve_selected_github_stack_observation
-from jj_stack.review.observation import (
-    RepositoryObservation,
-    observe_reviews,
-)
+from jj_stack.review.observation import observe_reviews
 from jj_stack.review.status import PreparedStatus, prepare_status, status_preparation_cli_error
 from jj_stack.review.trunk_evidence import TrackedReview
 from jj_stack.state.operation_lock import acquire_operation_lock
@@ -163,7 +161,6 @@ async def _run_selected_convergence(
             context=context,
             github_client=github,
             remote_name=target.remote.name,
-            trunk_branch=trunk_branch,
         )
         observation, github_stacks = await resolve_selected_github_stack_observation(
             context=context,
@@ -172,21 +169,7 @@ async def _run_selected_convergence(
             remote_name=target.remote.name,
             repository=target.repository,
             selected=selected,
-            trunk_branch=trunk_branch,
         )
-        error = _selected_observation_error(
-            observation=observation,
-            prepared_status=prepared_status,
-            target=target,
-            trunk_branch=trunk_branch,
-        )
-        if error is not None:
-            raise CliError(
-                error,
-                hint=t"Inspect the stack with {ui.cmd('jj-stack view')}, then repair it "
-                t"with {ui.cmd('jj-stack relink')} or republish it with "
-                t"{ui.cmd('jj-stack submit')}.",
-            )
         queued_pull_numbers = tuple(
             pull_request.number
             for revision in selected
@@ -213,6 +196,12 @@ async def _run_selected_convergence(
             dry_run=dry_run,
             github=github,
             plan=plan,
+            pull_requests={
+                pull_request.number: pull_request
+                for change in plan.on_trunk
+                if (pull_request := observation.reviews[change.candidate.change_id].pull_request)
+                is not None
+            },
             target=target,
             trunk_branch=trunk_branch,
             trunk_commit_id=prepared.stack.trunk.commit_id,
@@ -238,6 +227,7 @@ async def _apply_selected_plan(
     dry_run: bool,
     github: GithubClient,
     plan: SelectedConvergencePlan,
+    pull_requests: dict[int, GithubPullRequest],
     target: GithubTarget,
     trunk_branch: str,
     trunk_commit_id: str,
@@ -246,13 +236,12 @@ async def _apply_selected_plan(
         command=context,
         dry_run=dry_run,
         github=github,
-        remote_name=target.remote.name,
         trunk_branch=trunk_branch,
-        trunk_commit_id=trunk_commit_id,
     )
     results = await finish_reviews(
         candidates=tuple(change.candidate for change in plan.on_trunk),
         finish=finish_context,
+        pull_requests=pull_requests,
         skip_finish=frozenset(
             change.candidate.change_id
             for change in plan.on_trunk
@@ -340,14 +329,6 @@ async def _apply_selected_plan(
                 for change in plan.on_trunk
                 if change.revision is not None
                 and not change.revision.immutable
-                # Convergence already refused these, but repeat the work-loss check here because
-                # this is the step that actually discards commits.
-                and not (
-                    change.revision is not None
-                    and change.revision.holds_unpublished_edit(
-                        (change.candidate.submitted_baseline.commit_id,)
-                    )
-                )
                 and retirement_blocker(change.candidate) is None
             )
             if abandoned:
@@ -367,16 +348,10 @@ async def _apply_selected_plan(
         dry_run=dry_run,
         plan=plan,
     )
-    results = await retire_reviews(
-        evidence={change.candidate.change_id: change.evidence_kind for change in plan.on_trunk},
+    results = retire_reviews(
         finish_results=results,
         finish=finish_context,
         retirement_blocker=retirement_blocker,
-        terminal_required=frozenset(
-            change.candidate.change_id
-            for change in plan.on_trunk
-            if change.requires_terminal_pull_request
-        ),
     )
     render_finish_results(dry_run=dry_run, results=results)
     return finish_exit_code(base=update_result, results=results)
@@ -421,32 +396,6 @@ async def _update_selected_reviews(
         ) from error
     print_submit_result(result)
     return 0
-
-
-def _selected_observation_error(
-    *,
-    observation: RepositoryObservation,
-    prepared_status: PreparedStatus,
-    target: GithubTarget,
-    trunk_branch: str,
-) -> Message | None:
-    if (
-        observation.remote != target.remote
-        or observation.configured_repository != target.repository
-    ):
-        return "the configured Git remote changed during sync"
-    github_repository = observation.github_repository
-    assert github_repository is not None
-    if github_repository.full_name.casefold() != target.repository.full_name.casefold():
-        return "GitHub no longer reports the configured repository"
-    if github_repository.default_branch not in (None, "", trunk_branch):
-        return "GitHub no longer reports the selected trunk branch as its default"
-    expected_trunk = prepared_status.prepared.stack.trunk.commit_id
-    if observation.fetched_trunk_commit_id != expected_trunk:
-        return "fetched trunk changed during sync preparation"
-    if observation.remote_trunk_target != expected_trunk:
-        return "the live trunk ref moved after the fetch"
-    return None
 
 
 def _render_selected_plan(*, dry_run: bool, plan: SelectedConvergencePlan) -> None:

--- a/src/jj_stack/commands/sync_global.py
+++ b/src/jj_stack/commands/sync_global.py
@@ -21,6 +21,7 @@ from jj_stack.review.trunk_evidence import (
     CommitAncestry,
     TrackedReview,
     classify_commit_ancestries,
+    classify_exact_snapshot,
     classify_rewritten_result,
 )
 from jj_stack.ui import Message
@@ -95,6 +96,7 @@ async def run_global_recovery(*, context: CommandContext, dry_run: bool) -> int:
             candidates=exact_candidates,
             github_stacks=github_stacks,
             pull_requests=pull_requests,
+            repository=target.repository,
             tracked_pull_numbers=frozenset(
                 identity.pr_number
                 for identity in state.review_identities.values()
@@ -106,20 +108,24 @@ async def run_global_recovery(*, context: CommandContext, dry_run: bool) -> int:
             command=context,
             dry_run=dry_run,
             github=github,
-            remote_name=target.remote.name,
             trunk_branch=trunk_branch,
-            trunk_commit_id=trunk.commit_id,
         )
         results = await finish_reviews(
             candidates=eligible_exact,
             finish=finish_context,
+            pull_requests={
+                candidate.review_identity.pr_number: pull_request
+                for candidate in eligible_exact
+                if isinstance(
+                    pull_request := pull_requests.get(candidate.review_identity.pr_number),
+                    GithubPullRequest,
+                )
+            },
             skip_finish=terminal_required,
         )
-        results = await retire_reviews(
-            evidence={candidate.change_id: "exact" for candidate in eligible_exact},
+        results = retire_reviews(
             finish_results=results,
             finish=finish_context,
-            terminal_required=terminal_required,
         )
     render_finish_results(dry_run=dry_run, results=results)
     blocked = had_failure or any(result.outcome == "skipped" for result in results)
@@ -130,6 +136,7 @@ def _eligible_exact_candidates(
     candidates: tuple[TrackedReview, ...],
     github_stacks: tuple[GithubStack, ...],
     pull_requests: dict[int, GithubPullRequest | GithubClientError | None],
+    repository: github_resolution.GithubRepoAddress,
     tracked_pull_numbers: frozenset[int],
 ) -> tuple[tuple[TrackedReview, ...], frozenset[str]]:
     members = [member for stack in github_stacks for member in stack.pull_requests]
@@ -137,6 +144,27 @@ def _eligible_exact_candidates(
     terminal_required: set[str] = set()
     for candidate in candidates:
         number = candidate.review_identity.pr_number
+        pull_request = pull_requests.get(number)
+        if not isinstance(pull_request, GithubPullRequest):
+            reason = (
+                t"could not inspect its current review: {pull_request}"
+                if isinstance(pull_request, GithubClientError)
+                else t"GitHub no longer reports PR #{number}"
+            )
+            _warn_global_preserved(candidate, reason)
+            continue
+        evidence = classify_exact_snapshot(
+            ancestry="on_trunk",
+            candidate=candidate,
+            pull_request=pull_request,
+            repository=repository,
+        )
+        if not evidence.on_trunk:
+            _warn_global_preserved(
+                candidate,
+                evidence.reason or "the submitted review no longer matches",
+            )
+            continue
         matching = [member for member in members if member.number == number]
         if not matching:
             eligible.append(candidate)
@@ -145,7 +173,6 @@ def _eligible_exact_candidates(
             matching=matching,
             github_stacks=github_stacks,
             number=number,
-            pull_request=pull_requests.get(number),
             tracked_pull_numbers=tracked_pull_numbers,
         )
         if reason is not None:
@@ -161,7 +188,6 @@ def _github_stack_blocker(
     matching: list[GithubStackPullRequest],
     github_stacks: tuple[GithubStack, ...],
     number: int,
-    pull_request: object,
     tracked_pull_numbers: frozenset[int],
 ) -> Message | None:
     """Explain why a GitHub stack member cannot be retired repository-wide.
@@ -172,10 +198,6 @@ def _github_stack_blocker(
 
     if not matching[0].is_historical:
         return t"GitHub still lists PR #{number} as an active member of its stack"
-    if not isinstance(pull_request, GithubPullRequest):
-        return t"GitHub did not return usable data for PR #{number}"
-    if pull_request.normalize_state().state != "merged":
-        return t"GitHub does not report PR #{number} merged"
     if any(
         number in stack.pull_request_numbers
         and not set(stack.active_pull_request_numbers).isdisjoint(tracked_pull_numbers)

--- a/src/jj_stack/review/finish.py
+++ b/src/jj_stack/review/finish.py
@@ -1,33 +1,24 @@
 """Finish reviews whose work is proven to be on trunk, then stop tracking them.
 
 Finishing and untracking are kept separate: a pull request GitHub has ended is finished for good,
-while its tracking has to survive until nothing else needs it. Each step rechecks the evidence
-against live GitHub and trunk immediately before it acts.
+while its tracking has to survive until no local path still needs it.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from typing import Literal
 
 import jj_stack.console as console
 import jj_stack.ui as ui
 from jj_stack.bootstrap import CommandContext
-from jj_stack.errors import CliError, error_message
+from jj_stack.errors import error_message
 from jj_stack.github.client import GithubClient, GithubClientError
-from jj_stack.jj.client import JjCommandError
 from jj_stack.models.github import GithubPullRequest
 from jj_stack.ui import Message
 
-from .observation import RepositoryObservation, observe_reviews
-from .trunk_evidence import (
-    TrackedReview,
-    TrunkEvidenceKind,
-    classify_commit_ancestries,
-    classify_exact_snapshot,
-    collect_trunk_evidence,
-)
+from .trunk_evidence import TrackedReview
 
 ReviewFinishOutcome = Literal["finished", "already_terminal", "skipped"]
 
@@ -47,28 +38,31 @@ class FinishContext:
     command: CommandContext
     dry_run: bool
     github: GithubClient
-    remote_name: str
     trunk_branch: str
-    trunk_commit_id: str
 
 
 async def finish_reviews(
     *,
     candidates: tuple[TrackedReview, ...],
     finish: FinishContext,
+    pull_requests: Mapping[int, GithubPullRequest],
     skip_finish: frozenset[str] = frozenset(),
 ) -> tuple[ReviewFinishResult, ...]:
     """Finish the supplied reviews, reporting skipped ones as already terminal.
 
-    Callers pass their whole candidate list and name the ones GitHub has already finished, so
-    they do not each have to split the list and reinterleave the results afterwards.
+    Callers pass the PR snapshots that established each candidate's trunk evidence and name the
+    ones GitHub has already finished.
     """
 
     return tuple(
         [
             ReviewFinishResult(candidate=candidate, outcome="already_terminal")
             if candidate.change_id in skip_finish
-            else await _finish_review(candidate, finish)
+            else await _finish_review(
+                candidate,
+                finish,
+                pull_requests[candidate.review_identity.pr_number],
+            )
             for candidate in candidates
         ]
     )
@@ -77,162 +71,67 @@ async def finish_reviews(
 async def _finish_review(
     candidate: TrackedReview,
     finish: FinishContext,
+    pull_request: GithubPullRequest,
 ) -> ReviewFinishResult:
-    pull_request, reason = await _observe_review_on_trunk(candidate, finish)
-    if reason is not None or pull_request is None:
-        return ReviewFinishResult(candidate=candidate, outcome="skipped", skip_reason=reason)
+    pull_request = pull_request.normalize_state()
     if pull_request.state != "open":
         return ReviewFinishResult(candidate=candidate, outcome="already_terminal")
     if not finish.dry_run:
         console.output(t"Finishing PR #{pull_request.number} for {candidate.change_id}...")
-        pull_request, reason = await _finish_open_review(
-            candidate=candidate,
+        reason = await _finish_open_review(
             finish=finish,
             pull_request=pull_request,
         )
-        if reason is not None or pull_request is None:
+        if reason is not None:
             return ReviewFinishResult(candidate=candidate, outcome="skipped", skip_reason=reason)
     return ReviewFinishResult(candidate=candidate, outcome="finished")
 
 
 async def _finish_open_review(
     *,
-    candidate: TrackedReview,
     finish: FinishContext,
     pull_request: GithubPullRequest,
-) -> tuple[GithubPullRequest | None, Message | None]:
+) -> Message | None:
     try:
         if pull_request.base.ref != finish.trunk_branch:
-            await finish.github.update_pull_request(
-                pull_number=pull_request.number,
-                base=finish.trunk_branch,
-            )
-            reloaded, reason = await _observe_review_on_trunk(candidate, finish)
-            if reason is not None or reloaded is None:
-                return None, reason
-            pull_request = reloaded
+            pull_request = (
+                await finish.github.update_pull_request(
+                    pull_number=pull_request.number,
+                    base=finish.trunk_branch,
+                )
+            ).normalize_state()
             if pull_request.state != "open":
-                return pull_request, None
+                return None
             if pull_request.base.ref != finish.trunk_branch:
-                return None, t"PR #{pull_request.number} did not stay retargeted to trunk"
+                return t"PR #{pull_request.number} did not stay retargeted to trunk"
         await finish.github.close_pull_request(pull_number=pull_request.number)
-        close_conflict = False
     except GithubClientError as error:
-        if error.status_code != 422:
-            return None, t"could not finish cleanup for PR #{pull_request.number}: {error}"
-        close_conflict = True
-    reloaded, reason = await _observe_review_on_trunk(candidate, finish)
-    if reason is not None or reloaded is None:
-        return None, reason
-    if reloaded.state == "open":
-        return None, t"GitHub still reports PR #{reloaded.number} open after closing it"
-    if close_conflict and reloaded.state != "merged":
-        return None, t"GitHub rejected the close for PR #{reloaded.number} without merging it"
-    return reloaded, None
+        return t"could not finish cleanup for PR #{pull_request.number}: {error}"
+    return None
 
 
-async def _observe_review_on_trunk(
-    candidate: TrackedReview,
-    finish: FinishContext,
-) -> tuple[GithubPullRequest | None, Message | None]:
-    observation, reason = await observe_tracked_review(candidate, finish)
-    if reason is not None or observation is None:
-        return None, reason
-    pull_request = observation.reviews[candidate.change_id].pull_request
-    if pull_request is None:
-        return None, t"GitHub no longer reports PR #{candidate.review_identity.pr_number}"
-    pull_request = pull_request.normalize_state()
-    ancestry = classify_commit_ancestries(
-        commit_ids=(candidate.submitted_baseline.commit_id,),
-        context=finish.command,
-        trunk_commit_id=finish.trunk_commit_id,
-    )[candidate.submitted_baseline.commit_id]
-    evidence = classify_exact_snapshot(
-        ancestry=ancestry,
-        candidate=candidate,
-        pull_request=pull_request,
-        repository=finish.github.repository,
-    )
-    if not evidence.on_trunk:
-        return None, evidence.reason or "the submitted commit is not confirmed on trunk"
-    review = observation.reviews[candidate.change_id]
-    if pull_request.state == "open" and (
-        len(review.head_pull_requests) != 1
-        or review.head_pull_requests[0].number != pull_request.number
-    ):
-        return None, "the review branch no longer identifies exactly the saved pull request"
-    return pull_request, None
-
-
-async def observe_tracked_review(
-    candidate: TrackedReview,
-    finish: FinishContext,
-) -> tuple[RepositoryObservation | None, Message | None]:
-    try:
-        observation = await observe_reviews(
-            change_ids=(candidate.change_id,),
-            context=finish.command,
-            github_client=finish.github,
-            remote_name=finish.remote_name,
-            trunk_branch=finish.trunk_branch,
-        )
-    except (CliError, GithubClientError, JjCommandError) as error:
-        return None, t"could not recheck the repository and pull request: {error}"
-    if observation.remote is None or observation.remote.name != finish.remote_name:
-        return None, t"Git remote {ui.bookmark(finish.remote_name)} is no longer configured"
-    if observation.configured_repository != finish.github.repository:
-        return None, "the configured remote no longer names the expected GitHub repository"
-    github_repository = observation.github_repository
-    assert github_repository is not None
-    if github_repository.full_name.casefold() != finish.github.repository.full_name.casefold():
-        return None, "GitHub no longer reports the expected repository"
-    if github_repository.default_branch not in (None, "", finish.trunk_branch):
-        return None, "GitHub no longer reports the expected trunk branch as its default"
-    # Evidence here means "an ancestor of this trunk commit", so a trunk that rewound would let a
-    # stale answer claim the work is on trunk, and retiring on that abandons local commits
-    # for work that is not there. Unlike merge, which compares no trunk commits, this is
-    # load-bearing.
-    if observation.fetched_trunk_commit_id != finish.trunk_commit_id:
-        return None, t"fetched {ui.revset('trunk()')} changed while checking the merged PR"
-    if observation.remote_trunk_target != finish.trunk_commit_id:
-        return None, "the live trunk ref moved after the last fetch"
-    review = observation.reviews[candidate.change_id]
-    if (
-        review.identity != candidate.review_identity
-        or review.baseline != candidate.submitted_baseline
-    ):
-        return None, "saved PR tracking changed while checking the merged PR"
-    return observation, None
-
-
-async def retire_reviews(
+def retire_reviews(
     *,
-    evidence: dict[str, TrunkEvidenceKind],
     finish_results: tuple[ReviewFinishResult, ...],
     finish: FinishContext,
     retirement_blocker: Callable[[TrackedReview], Message | None] | None = None,
-    terminal_required: frozenset[str] = frozenset(),
 ) -> tuple[ReviewFinishResult, ...]:
     """Retire tracking independently, once each pull request has reached a terminal state."""
 
     context = finish.command
 
-    async def current_retirement_blocker(
-        candidate: TrackedReview,
-    ) -> Message | None:
+    def current_retirement_blocker(candidate: TrackedReview) -> Message | None:
         blocker = retirement_blocker(candidate) if retirement_blocker is not None else None
-        return blocker or await _fresh_retirement_blocker(
+        return blocker or _local_retirement_blocker(
             candidate=candidate,
-            evidence_kind=evidence[candidate.change_id],
             finish=finish,
-            terminal_required=candidate.change_id in terminal_required,
         )
 
     results = list(finish_results)
     active_results = filter(lambda item: item[1].outcome != "skipped", enumerate(results))
     for index, result in active_results:
         candidate = result.candidate
-        reason = await current_retirement_blocker(candidate)
+        reason = current_retirement_blocker(candidate)
         if reason is not None:
             results[index] = replace(result, retirement_skip_reason=reason)
             continue
@@ -251,12 +150,10 @@ async def retire_reviews(
     return tuple(results)
 
 
-async def _fresh_retirement_blocker(
+def _local_retirement_blocker(
     *,
     candidate: TrackedReview,
-    evidence_kind: TrunkEvidenceKind,
     finish: FinishContext,
-    terminal_required: bool,
 ) -> Message | None:
     local_revisions = finish.command.jj_client.query_revisions_by_change_ids(
         (candidate.change_id,)
@@ -268,25 +165,7 @@ async def _fresh_retirement_blocker(
         return t"{ui.change_id(candidate.change_id)} has unpublished local edits"
     if any(not revision.immutable for revision in local_revisions):
         return t"{ui.change_id(candidate.change_id)} still has an editable local revision"
-    observation, reason = await observe_tracked_review(candidate, finish)
-    if reason is not None or observation is None:
-        return reason
-    pull_request = observation.reviews[candidate.change_id].pull_request
-    if pull_request is None:
-        return t"GitHub no longer reports PR #{candidate.review_identity.pr_number}"
-    if terminal_required and pull_request.normalize_state().state != "merged":
-        return (
-            t"PR #{pull_request.number} belongs to a GitHub stack and does not report merged yet"
-        )
-    exact, rewritten = collect_trunk_evidence(
-        candidate=candidate,
-        context=finish.command,
-        pull_request=pull_request,
-        repository=finish.github.repository,
-        trunk_commit_id=finish.trunk_commit_id,
-    )
-    evidence = exact if evidence_kind == "exact" else rewritten
-    return None if evidence.on_trunk else evidence.reason
+    return None
 
 
 def finish_exit_code(*, base: int, results: Sequence[ReviewFinishResult]) -> int:

--- a/src/jj_stack/review/github_stack_sync.py
+++ b/src/jj_stack/review/github_stack_sync.py
@@ -55,7 +55,6 @@ async def resolve_selected_github_stack_observation(
     remote_name: str,
     repository: GithubRepoAddress,
     selected: tuple[LocalRevision, ...],
-    trunk_branch: str,
 ) -> tuple[review_observation.RepositoryObservation, tuple[GithubStack, ...]]:
     state = context.state_store.load()
     selected_change_ids = {revision.change_id for revision in selected}
@@ -96,7 +95,6 @@ async def resolve_selected_github_stack_observation(
         context=context,
         github_client=github,
         remote_name=remote_name,
-        trunk_branch=trunk_branch,
     )
     return observation, stacks if any(map(_changed_review, observation.reviews.values())) else ()
 

--- a/src/jj_stack/review/observation.py
+++ b/src/jj_stack/review/observation.py
@@ -35,11 +35,9 @@ class RepositoryObservation:
     """Fresh review facts shared by mutation policies."""
 
     configured_repository: github_resolution.GithubRepoAddress | None
-    fetched_trunk_commit_id: str | None
     github_repository: GithubRepository | None
     open_pull_requests_by_base: Mapping[str, tuple[GithubPullRequest, ...]] | None
     remote: GitRemote | None
-    remote_trunk_target: str | None
     repository: github_resolution.GithubRepoAddress
     reviews: Mapping[str, ReviewObservation]
 
@@ -70,7 +68,6 @@ async def observe_reviews(
     include_open_dependents: bool = False,
     remote_name: str | None = None,
     state_store: ReviewStateStore | None = None,
-    trunk_branch: str | None = None,
 ) -> RepositoryObservation:
     """Reload observations needed by an immediately following mutation."""
 
@@ -98,9 +95,7 @@ async def observe_reviews(
         github_client.get_repository() if context is not None else asyncio.sleep(0, result=None),
     )
     remote_targets: dict[str, str] = {}
-    remote_refs = tuple(
-        dict.fromkeys((*((trunk_branch,) if trunk_branch is not None else ()), *head_refs))
-    )
+    remote_refs = head_refs
     if context is not None and remote is not None and remote_refs:
         remote_targets = context.jj_client.list_remote_branches(
             remote=remote.name,
@@ -128,17 +123,11 @@ async def observe_reviews(
         for matches in (local_revisions.get(change_id, ()),)
     }
 
-    fetched_trunks = (
-        context.jj_client.query_revisions("trunk()", limit=2) if context is not None else ()
-    )
-    fetched_commit = fetched_trunks[0].commit_id if len(fetched_trunks) == 1 else None
     return RepositoryObservation(
         configured_repository=github_resolution.parse_github_repo(remote) if remote else None,
-        fetched_trunk_commit_id=fetched_commit,
         github_repository=github_repository,
         open_pull_requests_by_base=by_base,
         remote=remote,
-        remote_trunk_target=remote_targets.get(trunk_branch) if trunk_branch else None,
         repository=repository,
         reviews=reviews,
     )

--- a/tests/integration/test_sync_command.py
+++ b/tests/integration/test_sync_command.py
@@ -234,6 +234,27 @@ def test_sync_all_reports_a_failed_tracking_removal_in_its_exit_status(
     assert on_trunk.change_id in ReviewStateStore.for_repo(repo).load().review_identities
 
 
+def test_sync_all_preserves_tracking_when_exact_pr_head_changed(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=1)
+    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
+    (reviewed,) = selected_stack(repo).revisions
+    state_store = ReviewStateStore.for_repo(repo)
+    pull_request = fake_repo.pull_requests[1]
+    fake_repo.apply_merge_commit((pull_request,))
+    fake_repo.force_push_pull_request_head(pull_request)
+
+    exit_code = run_main(repo, config_path, "sync", "--all")
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "no longer reports the submitted head" in captured.err
+    assert reviewed.change_id in state_store.load().review_identities
+
+
 def test_sync_converges_stack_history_and_adopts_rewritten_survivor(
     tmp_path: Path,
     monkeypatch,

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -170,11 +170,9 @@ def _observation(
     pull_request = _pull_request()
     return RepositoryObservation(
         configured_repository=_REPOSITORY,
-        fetched_trunk_commit_id=None,
         github_repository=None,
         open_pull_requests_by_base={BRANCH: ()},
         remote=_REMOTE,
-        remote_trunk_target=None,
         repository=_REPOSITORY,
         reviews={
             CHANGE_ID: ReviewObservation(

--- a/tests/unit/test_merge.py
+++ b/tests/unit/test_merge.py
@@ -146,7 +146,6 @@ def test_merge_preconditions_reject_repository_drift() -> None:
             owner="other",
             repo="widgets",
         ),
-        fetched_trunk_commit_id=None,
         github_repository=_repository(
             allow_merge_commit=False,
             allow_rebase_merge=False,
@@ -158,7 +157,6 @@ def test_merge_preconditions_reject_repository_drift() -> None:
             fetch_url="https://github.test/acme/widgets.git",
             push_url="https://github.test/acme/widgets.git",
         ),
-        remote_trunk_target="trunk-commit",
         repository=expected_repository,
         reviews={},
     )


### PR DESCRIPTION
Sync plans already validate pull request snapshots and trunk evidence.
Carry that evidence into finalization, re-querying only local DAG facts
invalidated by sync's own rewrites instead of rebuilding external state
between effects.