### PR TITLE
list: warn about ambiguous review branches

### DIFF
--- a/docs/internals/design.md
+++ b/docs/internals/design.md
@@ -706,9 +706,10 @@ A per-change lookup failure marks only that row unresolved and produces an incom
 failure before any rows can be built returns its own exit code. `list` includes orphaned PRs as
 separate rows.
 
-`view` and `list` decide incompleteness from one shared per-change rule: an unmerged divergent
+`view` and `list` decide most incompleteness from one shared per-change rule: an unmerged divergent
 change, an ambiguous PR, a failed PR lookup, or a saved PR link the branch no longer resolves.
-One repository therefore cannot report complete from one command and incomplete from the other.
+When several local changes claim one saved branch, `list` warns, skips live inspection for that
+branch, and exits 10 rather than assigning its remote or PR state to the wrong change.
 Because a divergent change has several visible copies, every change-ID query selects all of them
 rather than resolving a bare change-ID symbol, which `jj` rejects as ambiguous.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -375,6 +375,10 @@ Use `jj-stack doctor --fix` to restore the normal fetch exclusion. If `doctor` n
 `remotes.<remote>.fetch-bookmarks` override, remove that setting if you want the exclusion to take
 effect.
 
+If `jj-stack list` says that a saved review branch is linked to several changes, it still shows
+every stack but skips live details for the affected changes. Relink the PR to the change that owns
+it, or clean up the stale saved review, then run `list` again.
+
 ## Another jj-stack operation is already running
 
 `jj-stack` takes one lock per repository so two mutating commands cannot interleave. If another

--- a/src/jj_stack/commands/list_.py
+++ b/src/jj_stack/commands/list_.py
@@ -45,7 +45,6 @@ from jj_stack.review.change_status import (
 )
 from jj_stack.review.repository import observe_repository_paths
 from jj_stack.review.status import (
-    PreparedRevision,
     PreparedStack,
     PullRequestLookup,
     ReviewStatusRevision,
@@ -133,6 +132,13 @@ def _run_list(
         discovered,
         current_review_commit_id=current_review_commit_id,
     )
+    duplicate_branches = duplicate_review_branch_claims(
+        (identity.head_ref, revision.change_id)
+        for stack in ordered
+        for revision in stack.revisions
+        if (identity := state.review_identities.get(revision.change_id)) is not None
+    )
+    duplicate_branch_names = frozenset(duplicate_branches)
     orphan_rows = tuple(
         _build_orphan_row(orphan) for orphan in enumerate_orphaned_records(state, ordered)
     )
@@ -170,6 +176,7 @@ def _run_list(
     with console.spinner(description="Inspecting review branches"):
         observed_remote_targets = observe_remote_targets_for_status(
             context=context,
+            excluded_branches=duplicate_branch_names,
             remote=github_target.remote,
             stacks=ordered,
             state=state,
@@ -191,8 +198,14 @@ def _run_list(
             )
             for stack in ordered
         )
-    _ensure_unique_repo_branches(prepared_discovered)
+    for branch, change_ids in sorted(duplicate_branches.items()):
+        console.warning(
+            t"Review branch {ui.bookmark(branch)} is saved for changes "
+            t"{ui.join(ui.change_id, change_ids)}. Live GitHub details for those changes "
+            t"were not inspected."
+        )
     pull_request_lookups, github_error = _load_pull_request_lookups(
+        excluded_branches=duplicate_branch_names,
         github_target=github_target,
         prepared_discovered=prepared_discovered,
     )
@@ -205,6 +218,7 @@ def _run_list(
         )
         for item in prepared_discovered
     )
+    incomplete = bool(duplicate_branches) or any(row.incomplete for row in rows)
     if as_json:
         console.output(
             json.dumps(
@@ -212,7 +226,7 @@ def _run_list(
                 indent=2,
             )
         )
-        return EXIT_INCOMPLETE if any(row.incomplete for row in rows) else 0
+        return EXIT_INCOMPLETE if incomplete else 0
     color_when = context.jj_client.resolve_color_when(
         cli_color=requested_color_mode(),
         stdout_is_tty=sys.stdout.isatty(),
@@ -234,7 +248,7 @@ def _run_list(
     )
     _emit_orphan_hint(orphan_rows)
     _emit_stale_stacks_advisory(discovered=ordered, state=state)
-    return EXIT_INCOMPLETE if any(row.incomplete for row in rows) else 0
+    return EXIT_INCOMPLETE if incomplete else 0
 
 
 def _build_orphan_row(orphan: OrphanedRecord) -> OrphanRow:
@@ -545,15 +559,21 @@ def _pull_request_numbers_from_revisions(
 
 def _load_pull_request_lookups(
     *,
+    excluded_branches: frozenset[str],
     github_target: GithubTarget | UnresolvedGithubTarget,
     prepared_discovered: tuple[_PreparedDiscoveredStack, ...],
 ) -> tuple[dict[str, PullRequestLookup], ErrorMessage | None]:
     if not isinstance(github_target, GithubTarget):
         return {}, None
 
-    prepared_revisions_by_branch = _tracked_prepared_revisions_by_branch(
-        prepared_discovered=prepared_discovered
-    )
+    prepared_revisions_by_branch = {
+        branch: revision
+        for item in prepared_discovered
+        for revision in item.prepared.status_revisions
+        if revision.review_identity is not None
+        and (branch := revision.branch) is not None
+        and branch not in excluded_branches
+    }
     if not prepared_revisions_by_branch:
         return {}, None
 
@@ -574,49 +594,12 @@ def _load_pull_request_lookups(
         return {}, error_message(error)
 
 
-def _tracked_prepared_revisions_by_branch(
-    *,
-    prepared_discovered: tuple[_PreparedDiscoveredStack, ...],
-) -> dict[str, PreparedRevision]:
-    prepared_revisions_by_branch: dict[str, PreparedRevision] = {}
-    for item in prepared_discovered:
-        for prepared_revision in item.prepared.status_revisions:
-            branch = prepared_revision.branch
-            if prepared_revision.review_identity is None or branch is None:
-                continue
-            prepared_revisions_by_branch[branch] = prepared_revision
-    return prepared_revisions_by_branch
-
-
 def _format_pull_request_summary(numbers: tuple[int, ...]) -> str:
     if not numbers:
         return ""
     if len(numbers) == 1:
         return f"PR {numbers[0]}"
     return f"{len(numbers)} PRs"
-
-
-def _ensure_unique_repo_branches(
-    prepared_discovered: tuple[_PreparedDiscoveredStack, ...],
-) -> None:
-    duplicates = duplicate_review_branch_claims(
-        (prepared_revision.branch, prepared_revision.revision.change_id)
-        for item in prepared_discovered
-        for prepared_revision in item.prepared.status_revisions
-        if prepared_revision.branch is not None
-    )
-    if not duplicates:
-        return
-
-    collisions = ui.join(
-        lambda item: t"{ui.bookmark(item[0])} for changes {ui.join(ui.change_id, item[1])}",
-        sorted(duplicates.items()),
-    )
-    raise CliError(
-        t"Could not safely inspect stacks: multiple changes resolve to the same "
-        t"review branch: {collisions}.",
-        hint="Repair the saved review linkage before retrying.",
-    )
 
 
 def _stack_table(

--- a/src/jj_stack/review/status.py
+++ b/src/jj_stack/review/status.py
@@ -468,6 +468,7 @@ def prepare_stack_for_status(
 def observe_remote_targets_for_status(
     *,
     context: CommandContext,
+    excluded_branches: frozenset[str] = frozenset(),
     remote: GitRemote | None,
     stacks: tuple[LocalStack, ...],
     state: ReviewState,
@@ -482,7 +483,7 @@ def observe_remote_targets_for_status(
             for stack in stacks
             for revision in stack.revisions
             for identity in (state.review_identities.get(revision.change_id),)
-            if identity is not None
+            if identity is not None and identity.head_ref not in excluded_branches
         )
     )
     if not branches:

--- a/tests/integration/test_list_command.py
+++ b/tests/integration/test_list_command.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import json
-from typing import ClassVar
 
 from jj_stack.errors import EXIT_INCOMPLETE
 from jj_stack.github.client import GithubClient, GithubClientError
-from jj_stack.jj.client import JjClient
 from jj_stack.state.store import ReviewStateStore
 
 from ..support.fake_github import FakeGithubState, create_app
@@ -341,7 +339,7 @@ def test_list_reports_partial_approval_for_ready_prefix_only(
     assert "1 approved, open" in captured.out
 
 
-def test_list_batches_remote_and_github_lookup_across_repo_stacks(
+def test_list_skips_colliding_branches_without_blocking_other_stack_lookups(
     tmp_path,
     monkeypatch,
     capsys,
@@ -349,47 +347,46 @@ def test_list_batches_remote_and_github_lookup_across_repo_stacks(
     repo, fake_repo = init_fake_github_repo_with_submitted_feature(tmp_path)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
 
-    run_command(["jj", "new", "main"], repo)
-    commit_file(repo, "feature 2", "feature-2.txt")
-    assert run_main(repo, config_path, "submit") == 0
-    capsys.readouterr()
+    change_ids = [selected_stack(repo).head.change_id]
+    for number in range(2, 5):
+        run_command(["jj", "new", "main"], repo)
+        commit_file(repo, f"feature {number}", f"feature-{number}.txt")
+        change_ids.append(selected_stack(repo).head.change_id)
+        assert run_main(repo, config_path, "submit") == 0
+        capsys.readouterr()
 
-    class CountingGithubClient(GithubClient):
-        pull_request_lookup_calls: ClassVar[list[tuple[str, ...]]] = []
-
-        async def get_pull_requests_by_head_refs(self, *, head_refs):
-            self.pull_request_lookup_calls.append(tuple(sorted(head_refs)))
-            return await super().get_pull_requests_by_head_refs(head_refs=head_refs)
-
-    app = create_app(FakeGithubState.single_repository(fake_repo))
-    patch_github_client_builders(
-        monkeypatch,
-        app=app,
-        fake_repo=fake_repo,
-        modules=("jj_stack.commands.list_", "jj_stack.review.status"),
-        client_type=CountingGithubClient,
+    state_store = ReviewStateStore.for_repo(repo)
+    state = state_store.load()
+    collided_branch = state.review_identities[change_ids[0]].head_ref
+    # A real collision needs matching random eight-character change-ID prefixes; bypass only the
+    # suffix check to construct the equivalent saved state cheaply.
+    monkeypatch.setattr("jj_stack.state.store.review_branch_matches_change", lambda *_: True)
+    state_store.relink_review(
+        change_ids[1],
+        identity=state.review_identities[change_ids[1]].model_copy(
+            update={"head_ref": collided_branch}
+        ),
+        baseline=state.submitted_baselines[change_ids[1]],
     )
-    original_list_remote_branches = JjClient.list_remote_branches
-    remote_branch_calls: list[tuple[str, ...]] = []
 
-    def list_remote_branches_once(self, *, remote, patterns=()):
-        remote_branch_calls.append(tuple(patterns))
-        return original_list_remote_branches(self, remote=remote, patterns=patterns)
-
-    monkeypatch.setattr(JjClient, "list_remote_branches", list_remote_branches_once)
-
-    exit_code = run_main(repo, config_path, "list")
+    exit_code = run_main(repo, config_path, "list", "--json")
     captured = capsys.readouterr()
+    changes = {
+        change["change_id"]: change
+        for row in json.loads(captured.out)["rows"]
+        for change in row["changes"]
+    }
 
-    assert exit_code == 0
-    assert "feature 1" in captured.out
-    assert "feature 2" in captured.out
-    assert "1 change" in captured.out
-    assert len(CountingGithubClient.pull_request_lookup_calls) == 1
-    assert len(CountingGithubClient.pull_request_lookup_calls[0]) == 2
-    assert len(remote_branch_calls) == 1
-    assert len(remote_branch_calls[0]) == 2
-    assert all(pattern.startswith("refs/heads/jj-stack/") for pattern in remote_branch_calls[0])
+    assert exit_code == EXIT_INCOMPLETE
+    assert collided_branch in captured.err
+    assert all(change_id[:8] in captured.err for change_id in change_ids[:2])
+    assert "Live GitHub details for those changes were not inspected" in captured.err
+    assert [changes[change_id]["pull_request"]["number"] for change_id in change_ids[:2]] == [
+        1,
+        2,
+    ]
+    assert all(changes[change_id]["status"] == "submitted" for change_id in change_ids[:2])
+    assert all(changes[change_id]["status"] == "open" for change_id in change_ids[2:])
 
 
 def test_list_reports_no_stacks_when_state_is_empty(


### PR DESCRIPTION
Listing is read-only and can still report useful saved state when several
changes claim one review branch. Skip ambiguous live attribution, warn
with the affected changes, and continue inspecting unaffected stacks.