### PR TITLE
tests: remove synthetic immutability scenarios

### DIFF
--- a/tests/integration/test_list_command.py
+++ b/tests/integration/test_list_command.py
@@ -165,30 +165,6 @@ def test_list_treats_a_visible_submitted_predecessor_as_published(
     assert [change["change_id"] for change in payload["rows"][0]["changes"]] == [change_id]
 
 
-def test_list_does_not_warn_when_tracked_stack_still_starts_at_mutable_trunk(
-    tmp_path,
-    monkeypatch,
-    capsys,
-) -> None:
-    repo, fake_repo = init_fake_github_repo(tmp_path)
-    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    run_command(
-        ["jj", "config", "set", "--repo", 'revset-aliases."immutable_heads()"', "none()"],
-        repo,
-    )
-
-    commit_file(repo, "alpha 1", "alpha-1.txt")
-    assert run_main(repo, config_path, "submit") == 0
-    capsys.readouterr()
-    head_change_id = selected_stack(repo).head.change_id
-
-    exit_code = run_main(repo, config_path, "list")
-    captured = capsys.readouterr()
-
-    assert exit_code == 0
-    assert head_change_id[:8] not in captured.err
-
-
 def test_list_extends_tracked_stack_through_unsubmitted_local_descendant(
     tmp_path,
     monkeypatch,
@@ -287,38 +263,6 @@ def test_list_inventories_paths_that_share_a_reviewed_prefix(
         (shared.change_id, left.change_id),
         (shared.change_id, right.change_id),
     }
-
-
-def test_list_keeps_current_tracked_stack_when_it_becomes_immutable(
-    tmp_path,
-    monkeypatch,
-    capsys,
-) -> None:
-    repo, fake_repo = init_fake_github_repo_with_submitted_feature(tmp_path)
-    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    feature = selected_stack(repo).head.commit_id
-    run_command(
-        [
-            "jj",
-            "config",
-            "set",
-            "--repo",
-            'revset-aliases."immutable_heads()"',
-            f"builtin_immutable_heads() | {feature}",
-        ],
-        repo,
-    )
-    head_change_id = selected_stack(repo).head.change_id
-
-    exit_code = run_main(repo, config_path, "list")
-    captured = capsys.readouterr()
-
-    assert exit_code == 0
-    assert "No stacks." not in captured.out
-    assert f"@ {head_change_id[:8]}" in captured.out
-    assert "feature 1" in captured.out
-    assert "PR 1" in captured.out
-    assert "1 change" in captured.out
 
 
 def test_list_reports_partial_approval_for_ready_prefix_only(

--- a/tests/integration/test_submit_command.py
+++ b/tests/integration/test_submit_command.py
@@ -991,57 +991,32 @@ def test_submit_rejects_a_conflicted_visible_review_bookmark(
     assert read_remote_ref(fake_repo.git_dir, identity.head_ref) == old_commit
 
 
-@pytest.mark.parametrize(
-    ("rewrite", "other_bookmark", "expected"),
-    (
-        (False, False, "immutable commits"),
-        (True, False, "divergent changes are not supported"),
-        (True, True, "divergent changes are not supported"),
-    ),
-)
-def test_visible_review_bookmark_preserves_other_immutability(
+def test_submit_rejects_divergence_kept_immutable_by_another_remote_bookmark(
     tmp_path: Path,
     monkeypatch,
     capsys,
-    rewrite: bool,
-    other_bookmark: bool,
-    expected: str,
 ) -> None:
     repo, fake_repo = init_fake_github_repo_with_submitted_feature(tmp_path)
     config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
     state = ReviewStateStore.for_repo(repo).load()
     change_id = next(iter(state.review_identities))
     baseline = state.submitted_baselines[change_id].commit_id
-    if rewrite:
-        run_command(["jj", "describe", "-r", change_id, "-m", "feature rewritten"], repo)
-    if other_bookmark:
-        run_command(
-            [
-                "git",
-                "--git-dir",
-                str(fake_repo.git_dir),
-                "update-ref",
-                "refs/heads/other-review-copy",
-                baseline,
-            ],
-            repo,
-        )
+    run_command(["jj", "describe", "-r", change_id, "-m", "feature rewritten"], repo)
+    run_command(
+        [
+            "git",
+            "--git-dir",
+            str(fake_repo.git_dir),
+            "update-ref",
+            "refs/heads/other-review-copy",
+            baseline,
+        ],
+        repo,
+    )
     run_command(["jj", "git", "fetch", "--remote", "origin", "--branch", "*"], repo)
-    if not other_bookmark:
-        run_command(
-            [
-                "jj",
-                "config",
-                "set",
-                "--repo",
-                'revset-aliases."immutable_heads()"',
-                f"builtin_immutable_heads() | {baseline}",
-            ],
-            repo,
-        )
 
     assert run_main(repo, config_path, "submit", change_id) == 2
-    assert expected in capsys.readouterr().err
+    assert "divergent changes are not supported" in capsys.readouterr().err
 
 
 def test_submit_does_not_claim_a_visible_bookmark_for_an_untracked_change(


### PR DESCRIPTION
Custom immutable-head configurations do not represent supported product
behavior and duplicate the ordinary divergence risk. Keep the realistic
remote-bookmark case and remove the synthetic matrix.