### PR TITLE
sync: remove speculative pull request fallback

### DIFF
--- a/docs/internals/implementation-strategy.md
+++ b/docs/internals/implementation-strategy.md
@@ -256,10 +256,8 @@ sequence.
 
 `sync --all` reads submitted-commit ancestry in chunks of up to 200 commits, reads PRs through
 GraphQL in chunks of 25, and then checks any reported merge-result commits in another batched
-ancestry read. If a GraphQL batch fails, bounded REST requests preserve a separate result for each
-PR. Missing commits and failed PR reads therefore remain local to their tracked changes. These
-reads produce the candidate results; PR updates and local retirement then run one candidate at a
-time.
+ancestry read. These reads produce the candidate results; PR updates and local retirement then
+run one candidate at a time.
 
 `submit` predicts GitHub auto-close risk before pushing rewritten review branches. The behavioral
 rule belongs to the submission algorithm in [design.md](design.md); the implementation uses one

--- a/src/jj_stack/commands/sync_global.py
+++ b/src/jj_stack/commands/sync_global.py
@@ -60,18 +60,20 @@ async def run_global_recovery(*, context: CommandContext, dry_run: bool) -> int:
             remote=target.remote,
             trunk_commit_id=trunk.commit_id,
         )
-        pull_requests = await github.get_pull_requests_by_numbers_independently(
-            pull_numbers=tuple(
-                candidate.review_identity.pr_number for candidate in all_candidates
+        try:
+            pull_requests = await github.get_pull_requests_by_numbers(
+                pull_numbers=tuple(
+                    candidate.review_identity.pr_number for candidate in all_candidates
+                )
             )
-        )
+        except GithubClientError as error:
+            raise CliError("Could not inspect tracked pull requests") from error
         github_stacks = await observe_github_stacks(github=github) if exact_candidates else ()
         merge_ancestry = classify_commit_ancestries(
             commit_ids=tuple(
                 pull_request.merge_commit_sha
                 for pull_request in pull_requests.values()
-                if isinstance(pull_request, GithubPullRequest)
-                and pull_request.merge_commit_sha is not None
+                if pull_request is not None and pull_request.merge_commit_sha is not None
             ),
             context=context,
             trunk_commit_id=trunk.commit_id,
@@ -116,10 +118,8 @@ async def run_global_recovery(*, context: CommandContext, dry_run: bool) -> int:
             pull_requests={
                 candidate.review_identity.pr_number: pull_request
                 for candidate in eligible_exact
-                if isinstance(
-                    pull_request := pull_requests.get(candidate.review_identity.pr_number),
-                    GithubPullRequest,
-                )
+                if (pull_request := pull_requests.get(candidate.review_identity.pr_number))
+                is not None
             },
             skip_finish=terminal_required,
         )
@@ -135,7 +135,7 @@ async def run_global_recovery(*, context: CommandContext, dry_run: bool) -> int:
 def _eligible_exact_candidates(
     candidates: tuple[TrackedReview, ...],
     github_stacks: tuple[GithubStack, ...],
-    pull_requests: dict[int, GithubPullRequest | GithubClientError | None],
+    pull_requests: dict[int, GithubPullRequest | None],
     repository: github_resolution.GithubRepoAddress,
     tracked_pull_numbers: frozenset[int],
 ) -> tuple[tuple[TrackedReview, ...], frozenset[str]]:
@@ -145,13 +145,8 @@ def _eligible_exact_candidates(
     for candidate in candidates:
         number = candidate.review_identity.pr_number
         pull_request = pull_requests.get(number)
-        if not isinstance(pull_request, GithubPullRequest):
-            reason = (
-                t"could not inspect its current review: {pull_request}"
-                if isinstance(pull_request, GithubClientError)
-                else t"GitHub no longer reports PR #{number}"
-            )
-            _warn_global_preserved(candidate, reason)
+        if pull_request is None:
+            _warn_global_preserved(candidate, t"GitHub no longer reports PR #{number}")
             continue
         evidence = classify_exact_snapshot(
             ancestry="on_trunk",
@@ -213,16 +208,14 @@ def _report_global_nonexact_candidate(
     candidate: TrackedReview,
     context: CommandContext,
     merge_ancestry: dict[str, CommitAncestry],
-    pull_request: GithubPullRequest | GithubClientError | None,
+    pull_request: GithubPullRequest | None,
     repository: github_resolution.GithubRepoAddress,
 ) -> bool:
-    if not isinstance(pull_request, GithubPullRequest):
-        reason = (
-            t"could not inspect its current review: {pull_request}"
-            if isinstance(pull_request, GithubClientError)
-            else t"GitHub no longer reports PR #{candidate.review_identity.pr_number}"
+    if pull_request is None:
+        return _warn_global_preserved(
+            candidate,
+            t"GitHub no longer reports PR #{candidate.review_identity.pr_number}",
         )
-        return _warn_global_preserved(candidate, reason)
     rewritten = classify_rewritten_result(
         candidate=candidate,
         merge_result_ancestry=merge_ancestry.get(pull_request.merge_commit_sha or ""),

--- a/src/jj_stack/github/client.py
+++ b/src/jj_stack/github/client.py
@@ -13,7 +13,6 @@ from textwrap import dedent, indent
 import httpxyz
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
-from jj_stack.concurrency import DEFAULT_BOUNDED_CONCURRENCY, run_bounded_tasks
 from jj_stack.errors import EXIT_GITHUB, SummarizedError
 from jj_stack.github.auth import github_token, github_token_from_env
 from jj_stack.github.resolution import GithubRepoAddress
@@ -270,38 +269,6 @@ class GithubClient:
                     ),
                 )
         return results
-
-    async def get_pull_requests_by_numbers_independently(
-        self,
-        *,
-        pull_numbers: Sequence[int],
-    ) -> dict[int, GithubPullRequest | GithubClientError | None]:
-        """Batch a lookup, then isolate individual results if the batch fails."""
-
-        numbers = tuple(sorted(set(pull_numbers)))
-        results: dict[int, GithubPullRequest | GithubClientError | None] = {}
-        try:
-            results.update(await self.get_pull_requests_by_numbers(pull_numbers=numbers))
-            return results
-        except GithubClientError:
-            pass
-
-        async def get_one(number: int) -> GithubPullRequest | GithubClientError:
-            try:
-                return await self.get_pull_request(pull_number=number)
-            except GithubClientError as error:
-                return error
-            except ValidationError:
-                return GithubClientError(
-                    f"GitHub pull request lookup returned invalid data for PR #{number}."
-                )
-
-        fallback_results = await run_bounded_tasks(
-            concurrency=DEFAULT_BOUNDED_CONCURRENCY,
-            items=numbers,
-            run_item=get_one,
-        )
-        return dict(zip(numbers, fallback_results, strict=True))
 
     async def get_pull_requests_by_head_refs(
         self,

--- a/tests/integration/test_sync_command.py
+++ b/tests/integration/test_sync_command.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import pytest
 
 import jj_stack.commands.sync as sync_command
-from jj_stack.errors import CliError
+from jj_stack.errors import EXIT_GITHUB, CliError
+from jj_stack.github.client import GithubClient, GithubClientError
 from jj_stack.jj.client import JjClient
 from jj_stack.state.store import ReviewStateError, ReviewStateStore, resolve_state_path
 
@@ -253,6 +254,28 @@ def test_sync_all_preserves_tracking_when_exact_pr_head_changed(
     assert exit_code == 1
     assert "no longer reports the submitted head" in captured.err
     assert reviewed.change_id in state_store.load().review_identities
+
+
+def test_sync_all_reports_batch_pull_request_failure_without_traceback(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=1)
+    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
+
+    async def fail_batch_lookup(self, *, pull_numbers):
+        raise GithubClientError("GitHub pull request batch lookup failed: unavailable")
+
+    monkeypatch.setattr(GithubClient, "get_pull_requests_by_numbers", fail_batch_lookup)
+
+    exit_code = run_main(repo, config_path, "sync", "--all")
+    captured = capsys.readouterr()
+
+    assert exit_code == EXIT_GITHUB
+    assert "Could not inspect tracked pull requests" in captured.err
+    assert "unavailable" in captured.err
+    assert "Traceback" not in captured.err
 
 
 def test_sync_converges_stack_history_and_adopts_rewritten_survivor(

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -6,10 +6,8 @@ import json
 import httpxyz
 import pytest
 
-from jj_stack.concurrency import DEFAULT_BOUNDED_CONCURRENCY
 from jj_stack.github.client import GithubClient, GithubClientError
 from jj_stack.github.resolution import GithubRepoAddress
-from jj_stack.models.github import GithubPullRequest
 
 
 def _github_client(handler, *, client_type=GithubClient) -> GithubClient:
@@ -334,52 +332,6 @@ def test_github_client_detects_merge_queue_branch_rule() -> None:
             return await client.base_branch_uses_merge_queue(branch="main")
 
     assert asyncio.run(run_test())
-
-
-@pytest.mark.merge_recovery
-def test_github_client_bounds_independent_pull_request_fallbacks() -> None:
-    class FallbackClient(GithubClient):
-        active = 0
-        max_active = 0
-
-        async def get_pull_requests_by_numbers(self, *, pull_numbers):
-            raise GithubClientError("forced batch failure")
-
-        async def get_pull_request(self, *, pull_number):
-            type(self).active += 1
-            type(self).max_active = max(type(self).max_active, type(self).active)
-            await asyncio.sleep(0)
-            try:
-                if pull_number == 1:
-                    raise GithubClientError("one failed")
-                if pull_number == 2:
-                    return GithubPullRequest.model_validate({})
-                return GithubPullRequest(
-                    base={"ref": "main"},
-                    head={"ref": f"jj-stack/{pull_number}"},
-                    html_url=f"https://github.test/pull/{pull_number}",
-                    number=pull_number,
-                    state="open",
-                    title=f"PR {pull_number}",
-                )
-            finally:
-                type(self).active -= 1
-
-    def unused_handler(request: httpxyz.Request) -> httpxyz.Response:
-        raise AssertionError(f"unexpected transport request: {request.url}")
-
-    async def run_test():
-        async with _github_client(unused_handler, client_type=FallbackClient) as client:
-            return await client.get_pull_requests_by_numbers_independently(
-                pull_numbers=tuple(range(1, 18)),
-            )
-
-    results = asyncio.run(run_test())
-
-    assert isinstance(results[1], GithubClientError)
-    assert isinstance(results[2], GithubClientError)
-    assert isinstance(results[3], GithubPullRequest)
-    assert FallbackClient.max_active == DEFAULT_BOUNDED_CONCURRENCY
 
 
 def test_github_client_rejects_graphql_payload_missing_repository_data() -> None:


### PR DESCRIPTION
A failed batched pull request read should fail sync cleanly. Do not replace
it with an unobserved REST fan-out policy; keep one read path and translate
its client error at the command boundary.