### PR TITLE
cli: remove the print timing shim

### DIFF
--- a/src/jj_stack/__init__.py
+++ b/src/jj_stack/__init__.py
@@ -1,6 +1,9 @@
 """Stacked GitHub review tooling for jj."""
 
 from importlib.metadata import PackageNotFoundError, version
+from time import perf_counter
+
+PROCESS_START = perf_counter()
 
 try:
     __version__ = version("jj-stack")

--- a/src/jj_stack/bootstrap.py
+++ b/src/jj_stack/bootstrap.py
@@ -8,6 +8,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+import jj_stack
 import jj_stack.console as console
 import jj_stack.ui as ui
 from jj_stack.config import AppConfig, load_config
@@ -23,8 +24,6 @@ _MINIMUM_JJ_VERSION = (0, 43, 0)
 _MINIMUM_JJ_VERSION_STRING = "0.43.0"
 _jj_version_verified = False
 
-APP_START = time.perf_counter()
-
 time_output_active: bool = False
 
 
@@ -35,7 +34,7 @@ class _ElapsedFormatter(logging.Formatter):
         base = super().format(record)
         if not time_output_active:
             return base
-        elapsed = time.perf_counter() - APP_START
+        elapsed = time.perf_counter() - jj_stack.PROCESS_START
         return console.style_time_prefix(f"[{elapsed:0.6f}] ") + base
 
 

--- a/src/jj_stack/cli.py
+++ b/src/jj_stack/cli.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-import builtins
-import io
 import logging
 import re
 import subprocess
 import sys
-import time
 from argparse import (
     SUPPRESS,
     ArgumentParser,
@@ -37,7 +34,6 @@ import jj_stack.commands.view as view_command
 import jj_stack.console as console
 import jj_stack.ui as ui
 from jj_stack import __version__
-from jj_stack.bootstrap import APP_START
 from jj_stack.cli_help import (
     HelpCommand,
     add_help_argument,
@@ -1135,65 +1131,11 @@ def _time_output(*, enabled: bool):
         yield
         return
 
-    original_print = builtins.print
-    at_line_start: dict[int, bool] = {}
-
-    def timed_print(*args, **kwargs) -> None:
-        elapsed = time.perf_counter() - APP_START
-        destination = kwargs.pop("file", sys.stdout)
-        flush = kwargs.pop("flush", False)
-        end = kwargs.get("end", "\n")
-        buffer = io.StringIO()
-        original_print(*args, file=buffer, flush=False, **kwargs)
-        rendered = buffer.getvalue()
-        if rendered:
-            prefix = f"[{elapsed:0.6f}] "
-            key = id(destination)
-            rendered_output, next_at_line_start = _prefix_rendered_output(
-                rendered,
-                prefix=prefix,
-                at_line_start=at_line_start.get(key, True),
-            )
-            destination.write(rendered_output)
-            at_line_start[key] = next_at_line_start
-        elif end:
-            key = id(destination)
-            rendered_output, next_at_line_start = _prefix_rendered_output(
-                end,
-                prefix=f"[{elapsed:0.6f}] ",
-                at_line_start=at_line_start.get(key, True),
-            )
-            destination.write(rendered_output)
-            at_line_start[key] = next_at_line_start
-        if flush:
-            destination.flush()
-
-    builtins.print = timed_print  # noqa: B010
     bootstrap.time_output_active = True
     try:
         yield
     finally:
         bootstrap.time_output_active = False
-        builtins.print = original_print  # noqa: B010
-
-
-def _prefix_rendered_output(
-    rendered: str,
-    *,
-    prefix: str,
-    at_line_start: bool,
-) -> tuple[str, bool]:
-    if not rendered:
-        return "", at_line_start
-
-    chunks: list[str] = []
-    current_at_line_start = at_line_start
-    for chunk in rendered.splitlines(keepends=True):
-        if current_at_line_start:
-            chunks.append(prefix)
-        chunks.append(chunk)
-        current_at_line_start = chunk.endswith("\n")
-    return "".join(chunks), current_at_line_start
 
 
 def _normalize_cli_args(argv: Sequence[str]) -> list[str]:

--- a/src/jj_stack/console.py
+++ b/src/jj_stack/console.py
@@ -6,16 +6,13 @@
 #   `configured_console()` context manager. Command modules should not need to manage
 #   console objects directly.
 #
-# - The module keeps stdout and stderr console setup in one place so we can
-#   migrate commands from `print(...)` incrementally without spreading Rich
-#   policy across the codebase.
+# - The module keeps stdout and stderr console setup in one place so command
+#   modules do not spread Rich policy across the codebase.
 #
 # - `markup=False` remains the default so arbitrary user-facing text does not
 #   need per-call Rich escaping.
 #
-# - Optional time-prefixing stays here even though most commands still use the
-#   legacy `print` shim today. We are likely to need the same behavior again as
-#   command output moves onto these helpers.
+# - Optional time-prefixing lives here alongside the output it affects.
 
 from __future__ import annotations
 
@@ -44,6 +41,7 @@ from rich.style import Style
 from rich.table import Table
 from rich.text import Text
 
+import jj_stack
 import jj_stack.ui as ui
 from jj_stack.jj.cli_args import JjCliArgs
 from jj_stack.jj.colors import SemanticStyles, load_semantic_styles
@@ -174,12 +172,10 @@ class _ConfiguredConsole:
         *,
         prefix_style: Style | None,
         start: float | None,
-        time_output: bool,
     ) -> None:
         self._console = console
         self._prefix_style = prefix_style
         self._start = start
-        self._time_output = time_output
 
     def print(
         self,
@@ -199,7 +195,7 @@ class _ConfiguredConsole:
         soft_wrap=None,
         new_line_start: bool = False,
     ) -> None:
-        if not self._time_output or self._start is None:
+        if self._start is None:
             self._console.print(
                 *objects,
                 sep=sep,
@@ -304,7 +300,6 @@ def _build_console(
     *,
     semantic_styles: SemanticStyles | None,
     time_output: bool,
-    start: float | None,
 ) -> _ConfiguredConsole:
     return _ConfiguredConsole(
         console,
@@ -313,8 +308,7 @@ def _build_console(
             if semantic_styles is None
             else semantic_styles.for_labels(("prefix", "timestamp"))
         ),
-        start=start,
-        time_output=time_output,
+        start=jj_stack.PROCESS_START if time_output else None,
     )
 
 
@@ -328,7 +322,6 @@ def _build_consoles(
     stdout: IO[str] | None = None,
     time_output: bool = False,
 ) -> tuple[_ConfiguredConsole, _ConfiguredConsole, SemanticStyles | None]:
-    start = time.perf_counter() if time_output else None
     stdout_console = _raw_console(sys.stdout if stdout is None else stdout, color_mode=color_mode)
     stderr_console = _raw_console(sys.stderr if stderr is None else stderr, color_mode=color_mode)
     # Semantic styles exist only to color output, and reading them costs one
@@ -344,13 +337,11 @@ def _build_consoles(
             stdout_console,
             semantic_styles=semantic_styles,
             time_output=time_output,
-            start=start,
         ),
         _build_console(
             stderr_console,
             semantic_styles=semantic_styles,
             time_output=time_output,
-            start=start,
         ),
         semantic_styles,
     )

--- a/tests/unit/test_ui.py
+++ b/tests/unit/test_ui.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+import jj_stack
 import jj_stack.console as console_module
 import jj_stack.jj.colors as jj_colors_module
 import jj_stack.ui as ui_module
@@ -26,31 +27,20 @@ def test_time_output_prefix_uses_prefix_and_timestamp_semantic_style(
         return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
 
     monkeypatch.setattr(jj_colors_module.subprocess, "run", fake_run)
-    monkeypatch.setattr(console_module.time, "perf_counter", lambda: 0.0)
+    monkeypatch.setattr(jj_stack, "PROCESS_START", 10.0)
+    monkeypatch.setattr(console_module.time, "perf_counter", lambda: 12.5)
 
-    console_cls = import_module("rich.console").Console
+    output = StringIO()
     with console_module.configured_console(
-        stdout=StringIO(),
+        stdout=output,
         stderr=StringIO(),
         color_mode="always",
         repository=repository,
         time_output=True,
     ):
-        console = console_cls(width=40)
-        lines = console.render_lines(
-            console_module._TimePrefixedRenderable(
-                renderable="timed",
-                end="",
-                prefix_style=console_module.semantic_style("prefix", "timestamp"),
-                start=0.0,
-            ),
-            console.options,
-            pad=False,
-        )
+        console_module.output("timed")
 
-    prefix_segment = lines[0][0]
-    assert prefix_segment.text == "[0.000000] "
-    assert prefix_segment.style == _style_cls()(color="cyan", bold=True)
+    assert output.getvalue() == "\x1b[1;36m[2.500000] \x1b[0mtimed\n"
 
 
 def test_semantic_style_uses_machine_readable_jj_config(


### PR DESCRIPTION
Command output already flows through configured consoles. Remove global print
interception and use one process-start timestamp for both console output and
bootstrap logging.