### PR TITLE
submit: remove the post-push closure check

### DIFF
--- a/docs/internals/design.md
+++ b/docs/internals/design.md
@@ -444,11 +444,6 @@ rewrite, `submit` may temporarily retarget selected PRs to prevent GitHub from a
 whose new base contains its head. An interruption may leave bases at their old value, trunk, or
 the desired parent; a rerun finishes the update without replacing PRs.
 
-After all planned work, `submit` refetches every selected PR that was open at the start. If one is
-now closed or missing, it fails loudly and tells the user how to inspect or reopen it. This
-post-check detects GitHub-side changes that the pre-push model could not prevent; it never hides
-them by silently replacing tracking.
-
 An open PR currently in a merge queue is not updated. `submit` stops the selected stack before
 moving any review branch or changing any PR, and tells the user to wait for GitHub to merge it.
 This does not restrict commands on independent stacks.

--- a/src/jj_stack/commands/submit/auto_close.py
+++ b/src/jj_stack/commands/submit/auto_close.py
@@ -1,4 +1,4 @@
-"""Predict and detect GitHub's reachability-based pull request auto-close."""
+"""Prevent GitHub's reachability-based pull request auto-close."""
 
 from __future__ import annotations
 
@@ -7,7 +7,6 @@ from jj_stack.concurrency import DEFAULT_BOUNDED_CONCURRENCY, run_bounded_tasks
 from jj_stack.errors import CliError
 from jj_stack.github.client import GithubClient, GithubClientError
 from jj_stack.jj.client import JjClient
-from jj_stack.models.github import GithubPullRequest
 
 from .models import PendingPullRequestSync, PreparedSubmitRevision
 
@@ -107,75 +106,3 @@ async def _retarget_review_base_before_branch_push(
             t"Could not retarget PR #{pull_request.number} to "
             t"{ui.bookmark(trunk_branch)} before pushing review branches"
         ) from error
-
-
-async def verify_no_unexpected_pull_request_closures(
-    *,
-    discovered_pull_requests: dict[str, GithubPullRequest | None],
-    github_client: GithubClient,
-) -> None:
-    """Detect open→closed and open→missing transitions and raise loudly.
-
-    `submit` never closes pull requests on purpose. Any PR that was open at the
-    start of this run and is no longer open by the end means a GitHub destructive
-    default fired in a way the pre-push predictor did not anticipate (typically
-    the head-contained-in-base auto-close) or the PR vanished entirely (deleted
-    or transferred). Surface either case loudly rather than persist state that
-    hides the loss.
-    """
-
-    initially_open_numbers = sorted(
-        {
-            pull_request.number
-            for pull_request in discovered_pull_requests.values()
-            if pull_request is not None and pull_request.state == "open"
-        }
-    )
-    if not initially_open_numbers:
-        return
-    try:
-        refetched = await github_client.get_pull_requests_by_numbers(
-            pull_numbers=initially_open_numbers,
-        )
-    except GithubClientError as error:
-        raise CliError(
-            "Could not refetch pull request states for the post-submit safety check"
-        ) from error
-
-    closed_numbers: list[int] = []
-    missing_numbers: list[int] = []
-    for number in initially_open_numbers:
-        pull_request = refetched.get(number)
-        if pull_request is None:
-            missing_numbers.append(number)
-            continue
-        if pull_request.state != "open":
-            closed_numbers.append(number)
-    if not closed_numbers and not missing_numbers:
-        return
-
-    message_parts: list[ui.Message] = []
-    if closed_numbers:
-        closed_rendered = ", ".join(f"#{number}" for number in closed_numbers)
-        message_parts.append(
-            t"Pull request(s) {closed_rendered} were open at the start of this submit "
-            t"but are closed by the end. GitHub closes a pull request automatically "
-            t"when its head commit becomes reachable from the base branch during a "
-            t"push. Reopen those pull requests on GitHub now to keep their existing "
-            t"reviews."
-        )
-    if missing_numbers:
-        missing_rendered = ", ".join(f"#{number}" for number in missing_numbers)
-        if message_parts:
-            message_parts.append(" ")
-        message_parts.append(
-            t"Pull request(s) {missing_rendered} were open at the start of this "
-            t"submit but GitHub no longer reports them. Inspect those pull requests "
-            t"on GitHub to see whether they were deleted or transferred."
-        )
-    message_parts.append(" ")
-    message_parts.append(
-        t"Once the affected pull requests are restored, rerunning "
-        t"{ui.cmd('jj-stack submit')} is safe and will restore the stacked bases."
-    )
-    raise CliError(tuple(message_parts))

--- a/src/jj_stack/commands/submit/command.py
+++ b/src/jj_stack/commands/submit/command.py
@@ -647,11 +647,6 @@ async def run_submit_async(
                     revisions=submitted_revisions,
                 ),
             )
-            await auto_close.verify_no_unexpected_pull_request_closures(
-                discovered_pull_requests=discovered_pull_requests,
-                github_client=github_client,
-            )
-
     return _build_submit_result(
         client=client,
         dry_run=dry_run,

--- a/tests/unit/test_submit.py
+++ b/tests/unit/test_submit.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from dataclasses import replace
 from types import SimpleNamespace
 from typing import cast
@@ -8,9 +7,6 @@ from typing import cast
 import pytest
 
 from jj_stack.bootstrap import CommandContext
-from jj_stack.commands.submit.auto_close import (
-    verify_no_unexpected_pull_request_closures,
-)
 from jj_stack.commands.submit.command import (
     _resolve_submit_options,
 )
@@ -27,7 +23,6 @@ from jj_stack.commands.submit.pull_requests import (
 from jj_stack.commands.submit.revisions import prepare_submit_revisions
 from jj_stack.config import AppConfig
 from jj_stack.errors import CliError
-from jj_stack.github.client import GithubClient
 from jj_stack.models.git import GitRemote
 from jj_stack.models.github import (
     GithubBranchRef,
@@ -231,25 +226,6 @@ def test_reviewers_to_re_request_uses_latest_actionable_state_per_reviewer() -> 
     assert _reviewers_to_re_request(reviews) == ["erin"]
 
 
-@pytest.mark.parametrize("refetched", (None, "closed"))
-def test_submit_detects_pull_request_that_is_no_longer_open(
-    refetched: str | None,
-) -> None:
-    client = _RefetchPullRequestsClient(
-        refetched={
-            2: (None if refetched is None else _github_pull_request(number=2, state=refetched))
-        },
-    )
-
-    with pytest.raises(CliError):
-        asyncio.run(
-            verify_no_unexpected_pull_request_closures(
-                discovered_pull_requests={"jj-stack/foo": _github_pull_request(number=2)},
-                github_client=cast(GithubClient, client),
-            )
-        )
-
-
 def test_resolve_submit_options_prefers_cli_values_over_config() -> None:
     context = cast(
         CommandContext,
@@ -334,18 +310,6 @@ def _reviews(*specs: tuple[int, str, str]) -> tuple[GithubPullRequestReview, ...
         )
         for review_id, login, state in specs
     )
-
-
-class _RefetchPullRequestsClient:
-    def __init__(self, *, refetched: dict[int, GithubPullRequest | None]) -> None:
-        self._refetched = refetched
-
-    async def get_pull_requests_by_numbers(
-        self,
-        *,
-        pull_numbers,
-    ) -> dict[int, GithubPullRequest | None]:
-        return {number: self._refetched.get(number) for number in pull_numbers}
 
 
 def _github_pull_request(


### PR DESCRIPTION
The prepared ref plan already predicts and prevents GitHub auto-closures
before the atomic push. Remove the duplicate post-hoc observation, which
could only report damage after the mutation.