### PR TITLE
tests: restore property-suite discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
         run: >-
           tests/run_submit_property_scenarios.py 10 --random-seed -n auto
           --stack-join-scenarios 5
+          --lifecycle-scenarios 10
           --stack-move-scenarios 5
           --retry-scenarios 5
           --drift-scenarios 21

--- a/docs/internals/distributed-state.md
+++ b/docs/internals/distributed-state.md
@@ -4,10 +4,11 @@ Status: current drift model. [design.md](design.md) defines product behavior.
 
 `jj-stack` coordinates three systems that can move independently. Drift bugs arise when they
 disagree. Local tracking records what `jj-stack` previously did; it is not another independently
-moving system. This file names the supported external transitions and the required behavior for
-each kind of drift. The property harness ([property-testing.md](property-testing.md)) generates
-the rows marked "property" below; focused command tests cover the rows marked "deterministic."
-Rows marked "specified" have defined behavior but no dedicated current scenario.
+moving system. This file inventories the external transitions covered by tests; it does not
+define product behavior. The property harness ([property-testing.md](property-testing.md))
+generates the rows marked "property" below; focused command tests cover the rows marked
+"deterministic." Rows marked "specified" are defined in [design.md](design.md) but have no
+dedicated current scenario.
 
 ## Independently moving systems
 
@@ -44,7 +45,6 @@ the generated scenario code records only the source expected to produce the prim
 | Drift kind | Affected input(s) | `submit` outcome | Coverage |
 | --- | --- | --- | --- |
 | `closed_pr` | GitHub PRs | fail closed (exit 1) | property |
-| `merged_pr` | GitHub PRs | fail closed (1) | property |
 | `pr_replaced` | GitHub PRs | fail closed (1) | property |
 | `repository_retargeted` | config, GitHub | fail closed (1) | specified |
 | `head_ref_renamed` | GitHub PRs | fail closed (1) | specified |
@@ -69,7 +69,9 @@ the *local* stack:
   rewrite already replaced, the fetch resurrects the hidden predecessor and the change
   becomes divergent; even resolving the change ID to a single revision fails.
 
-## Required behavior per drift class
+## Assertions made by drift coverage
+
+The harness applies the rules from [design.md](design.md) through these shared assertions:
 
 - **Repairable drift.** Drift that cannot corrupt review identity is repaired or ignored by the
   next `submit`: bases are recomputed from the DAG, trunk advances are irrelevant to review-branch

--- a/docs/internals/implementation-strategy.md
+++ b/docs/internals/implementation-strategy.md
@@ -446,9 +446,10 @@ Implemented local coverage includes:
 
 - unit tests for parsing, planning, and model behavior
 - local integration tests against the fake GitHub server and a real backing Git repo
-- five fixed generated/property cases that replay the integration harness in the default suite
-- focused merge and recovery cases, including atomic stack-merge failure, partial survivor
-  rewrites, terminal retry, single-PR merge topology, and multi-PR rewriting-merge convergence
+- eight fixed generated/property cases that replay the integration harness in the default suite,
+  including three completed-command lifecycle cases
+- focused merge and recovery cases, including atomic stack-merge failure, terminal retry, and
+  single-PR merge topology
 
 Local tests are the default.
 

--- a/docs/internals/property-testing.md
+++ b/docs/internals/property-testing.md
@@ -28,11 +28,11 @@ testing should spend its budget on those cross-system invariants.
 - Catch transient damage, not only final state. The fake GitHub server should record PR
   state-transition events, and property tests should fail if a selected-stack PR ever
   transitions closed or merged during a successful resubmit.
-- Include external-drift coverage driven by an explicit transition model. A separate
-  scenario family perturbs the external systems or local `jj` view after initial submit, using
-  only transitions an ordinary user, teammate, or agent can perform. The model predicts whether
-  `submit` must fail closed without mutating any boundary or succeed with the normal contract,
-  and every drifted state must still produce a `view` report instead of a crash. See
+- Include external-drift coverage driven by an explicit transition model. A separate scenario
+  family applies one external or local drift after initial submit, using only transitions an
+  ordinary user, teammate, or agent can perform. The model predicts whether `submit` must fail
+  closed without mutating any boundary or succeed with the normal contract, and every drifted
+  state must still produce a `view` report instead of a crash. See
   [distributed-state.md](distributed-state.md) for the sources-of-state model behind the
   vocabulary.
 - Make failures reproducible. Every generated scenario must have a stable name and a
@@ -133,10 +133,10 @@ the `view` warning after a reviewed path gains a sibling.
 
 Stack-edit scenarios cover successful repair after supported local DAG rewrites. They do
 not cover behavior when another source of state has moved independently. The external-drift
-family starts from a submitted, approved stack, optionally applies one local stack edit
-from the stack-edit vocabulary, then applies one drift operation from a typed transition
-vocabulary. Each drift kind is data: the boundary it mutates, whether it targets one
-submitted change, and the modeled `submit` outcome.
+family starts from a submitted, approved stack, optionally applies one local stack edit from the
+stack-edit vocabulary, then applies one drift operation from a typed transition vocabulary. Each
+drift kind is data: the boundary it mutates, whether it targets one submitted change, and the
+modeled `submit` outcome.
 [distributed-state.md](distributed-state.md) owns the drift inventory and expected outcomes.
 
 Fail-closed kinds (for example an externally closed, merged, or replaced PR, a drifted or deleted
@@ -162,14 +162,16 @@ unclassified error. Exact diagnostic wording stays out of scope.
 
 ## Merge and sync coverage
 
-Merge and post-merge convergence use focused deterministic integration tests rather than the
-stack-edit generator. A small lifecycle family covers cleanup, restart, and automatic sync;
-expanded runs add rebase cleanup. The deterministic tests cover exact submitted-head validation,
-bottom-prefix selection, draft and closed boundaries, atomic stack-merge failure, partial stack
-merge survivor rewrites, terminal retry, historical-member cleanup, and selected or
-repository-wide sync eligibility.
+Merge and post-merge convergence use focused deterministic integration tests and a bounded
+lifecycle family rather than the stack-edit generator. The three fixed lifecycle cases cover
+cleanup, restart, and automatic sync after a partial rebase merge. Expanded runs sample the
+finite direct-merge grid: stack sizes one through five, every nonempty bottom prefix, and rebase
+or squash. A whole-stack squash merge is the first expanded representative. Focused tests cover
+exact submitted-head validation, bottom-prefix selection, draft and closed boundaries, atomic
+stack-merge failure, terminal retry, historical-member cleanup, and selected or repository-wide
+sync eligibility.
 
-The stack-merge tests assert both final Git and PR state and the significant API events. A
+The lifecycle cases assert final Git and PR state and the significant merge request. A
 terminal stack-merge failure changes nothing. A successful partial request may change survivor
 heads and bases. A terminal direct `merge` validates and converges that transition before
 returning, including when a middle pull request names the merge boundary but higher survivors
@@ -255,7 +257,8 @@ $ tests/run_submit_property_scenarios.py 500
 ```
 
 The runner's `--help` lists family counts, seeds, workers, environment setup, and
-additional pytest arguments.
+additional pytest arguments. Pytest arguments must follow a literal `--`; unknown arguments
+before it are runner errors.
 
 `--random-seed` generates one seed and uses it for both scenario generation and
 pytest-randomly ordering. The runner prints a complete reproduction invocation with the

--- a/tests/integration/test_sync_command.py
+++ b/tests/integration/test_sync_command.py
@@ -145,39 +145,6 @@ def test_sync_recovers_a_clean_single_review_rebase_merge(
     assert reviewed.change_id not in state_store.load().review_identities
 
 
-def test_merge_by_middle_pull_request_automatically_syncs_the_unnamed_survivors(
-    tmp_path: Path,
-    monkeypatch,
-    capsys,
-) -> None:
-    repo, fake_repo = init_fake_github_repo_with_submitted_stack(tmp_path, size=4)
-    config_path = configure_submit_environment(monkeypatch, tmp_path, fake_repo)
-    stack = selected_stack(repo)
-    survivors = stack.revisions[2:]
-    survivor_commits_before = tuple(revision.commit_id for revision in survivors)
-
-    merge_exit_code = run_main(repo, config_path, "merge", "--pull-request", "2")
-    merged = capsys.readouterr()
-
-    assert merge_exit_code == 0, (merged.out, merged.err)
-    assert all(fake_repo.pull_requests[number].merged_at is not None for number in (1, 2))
-    assert all(fake_repo.pull_requests[number].state == "open" for number in (3, 4))
-    assert "Updating the local stack after the completed merge" in merged.out
-    merged_trunk_commit = read_remote_ref(fake_repo.git_dir, "main")
-    rewritten_survivors = tuple(
-        JjClient(repo).resolve_revision(revision.change_id) for revision in survivors
-    )
-    rewritten_commits = tuple(revision.commit_id for revision in rewritten_survivors)
-    assert rewritten_commits != survivor_commits_before
-    assert rewritten_commits == tuple(
-        fake_repo.ref_target(fake_repo.pull_requests[number].head_ref) for number in (3, 4)
-    )
-    assert rewritten_survivors[0].parents == (merged_trunk_commit,)
-    assert rewritten_survivors[1].parents == (rewritten_survivors[0].commit_id,)
-    assert fake_repo.pull_requests[3].base_ref == "main"
-    assert fake_repo.pull_requests[4].base_ref == fake_repo.pull_requests[3].head_ref
-
-
 def test_sync_reports_a_failed_tracking_removal_in_its_exit_status(
     tmp_path: Path,
     monkeypatch,

--- a/tests/run_submit_property_scenarios.py
+++ b/tests/run_submit_property_scenarios.py
@@ -7,6 +7,7 @@ import os
 import secrets
 import shlex
 import subprocess
+import sys
 from argparse import ArgumentParser, ArgumentTypeError
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -87,7 +88,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--lifecycle-scenarios",
         type=_non_negative_int,
-        help="Number of completed-command lifecycle scenarios to run (default: all 4).",
+        help="Number of completed-command lifecycle scenarios to run (default: all 3).",
     )
     parser.add_argument(
         "-n",
@@ -100,9 +101,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="store_true",
         help="Skip uv sync --locked before running pytest.",
     )
-    args, pytest_args = parser.parse_known_args(argv)
-    if pytest_args and pytest_args[0] == "--":
-        pytest_args = pytest_args[1:]
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    separator = arguments.index("--") if "--" in arguments else len(arguments)
+    args = parser.parse_args(arguments[:separator])
+    pytest_args = arguments[separator + 1 :] if separator < len(arguments) else []
     _validate_jobs(args.jobs, parser)
 
     if not args.no_sync:
@@ -134,7 +136,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     env["JJ_STACK_SUBMIT_PROPERTY_DRIFT_SCENARIOS"] = str(drift_scenarios)
     lifecycle_scenarios = args.lifecycle_scenarios
     env["JJ_STACK_SUBMIT_PROPERTY_LIFECYCLE_SCENARIOS"] = str(
-        4 if lifecycle_scenarios is None else lifecycle_scenarios
+        3 if lifecycle_scenarios is None else lifecycle_scenarios
     )
     seed = secrets.randbits(32) if args.random_seed else args.seed
     if seed is None:

--- a/tests/support/submit_property_harness.py
+++ b/tests/support/submit_property_harness.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -63,7 +62,8 @@ def replay_lifecycle(
     scenario: LifecycleScenario,
 ) -> None:
     jj = JjClient(repo)
-    stack_size, merged_prefix = (4, 2) if scenario.template == "direct_merge" else (1, 1)
+    stack_size = scenario.stack_size
+    merged_prefix = scenario.merged_prefix
     labels = _create_initial_stack(repo, stack_size)
     assert run_cli(("submit",)) == 0
     baseline = _capture_submitted_baseline(repo, fake_repo, labels)
@@ -91,9 +91,27 @@ def replay_lifecycle(
         assert len(fake_repo.pull_requests) == 2
         return
     if scenario.template == "direct_merge":
-        fake_repo.allow_rebase_merge = True
-        assert run_cli(("merge", "--method", "rebase", "--pull-request", "2")) == 0
-        expected_request = (2, "rebase", "direct_merge", baseline["c2"].remote_target)
+        if scenario.merge_method == "rebase":
+            fake_repo.allow_rebase_merge = True
+        boundary = baseline[initial_label(merged_prefix)]
+        assert (
+            run_cli(
+                (
+                    "merge",
+                    "--method",
+                    scenario.merge_method,
+                    "--pull-request",
+                    str(boundary.pr_number),
+                )
+            )
+            == 0
+        )
+        expected_request = (
+            boundary.pr_number,
+            scenario.merge_method,
+            "direct_merge",
+            boundary.remote_target,
+        )
         assert fake_repo.stack_merge_requests == [expected_request]
     else:
         pull_request = fake_repo.pull_requests[1]
@@ -124,17 +142,22 @@ def replay_lifecycle(
             assert copy.immutable and not copy.divergent
             assert copy.commit_id == fake_repo.pull_requests[submitted.pr_number].merge_commit_sha
     previous_base = "main"
+    previous_commit = _remote_head(refs, "main")
     for index in range(merged_prefix + 1, stack_size + 1):
         label = initial_label(index)
         submitted = baseline[label]
         assert state.review_identities[submitted.change_id].pr_number == submitted.pr_number
         assert fake_repo.pull_requests[submitted.pr_number].state == "open"
         revision = jj.resolve_revision(submitted.change_id)
+        assert revision.parents == (previous_commit,)
+        if scenario.template == "direct_merge":
+            assert revision.commit_id != submitted.remote_target
         assert refs[f"refs/heads/{submitted.branch}"] == revision.commit_id
         assert state.submitted_baselines[submitted.change_id].commit_id == revision.commit_id
         assert fake_repo.pull_requests[submitted.pr_number].base_ref == previous_base
         _assert_approval_review_preserved(fake_repo, submitted.pr_number, label)
         previous_base = submitted.branch
+        previous_commit = revision.commit_id
     assert len(fake_repo.pull_requests) == stack_size
 
 
@@ -245,20 +268,19 @@ def replay_external_drift_scenario(
         )
 
     submit_revset = labels_to_change_ids[scenario.final_live_labels[-1]]
-    for drift in scenario.drifts:
-        revset_override = _apply_drift_operation(
-            baseline=baseline,
-            drift=drift,
-            fake_repo=fake_repo,
-            labels_to_change_ids=labels_to_change_ids,
-            repo=repo,
-            run_cli=run_cli,
-        )
-        discard_output()
-        if revset_override is not None:
-            submit_revset = revset_override
+    revset_override = _apply_drift_operation(
+        baseline=baseline,
+        drift=scenario.drift,
+        fake_repo=fake_repo,
+        labels_to_change_ids=labels_to_change_ids,
+        repo=repo,
+        run_cli=run_cli,
+    )
+    discard_output()
+    if revset_override is not None:
+        submit_revset = revset_override
 
-    if scenario.expected_outcome == "fail_closed":
+    if scenario.drift.spec.expected_outcome == "fail_closed":
         before_refs = _remote_refs(fake_repo.git_dir)
         before_github = _github_snapshot(fake_repo)
         before_imported_reviews = JjClient(repo).visible_review_bookmark_targets()
@@ -270,7 +292,7 @@ def replay_external_drift_scenario(
         discard_output()
 
         failure = (exit_code, diagnosis)
-        assert failure in scenario.expected_failures, (failure, scenario.trace)
+        assert failure in scenario.drift.spec.failures, (failure, scenario.trace)
         assert _remote_refs(fake_repo.git_dir) == before_refs, scenario.trace
         assert _github_snapshot(fake_repo) == before_github, scenario.trace
         assert fake_repo.pull_request_events == [], scenario.trace
@@ -1024,14 +1046,6 @@ def _apply_drift_operation(
     if drift.kind == "closed_pr":
         fake_repo.update_pull_request_state(
             fake_repo.pull_requests[submitted.pr_number],
-            state="closed",
-        )
-        return None
-    if drift.kind == "merged_pr":
-        pull_request = fake_repo.pull_requests[submitted.pr_number]
-        pull_request.merged_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
-        fake_repo.update_pull_request_state(
-            pull_request,
             state="closed",
         )
         return None

--- a/tests/support/submit_property_scenarios.py
+++ b/tests/support/submit_property_scenarios.py
@@ -17,7 +17,6 @@ from .stack_edit_scenarios import (
 DriftKind = Literal[
     "closed_pr",
     "foreign_branch_fetched",
-    "merged_pr",
     "pr_base_retargeted",
     "pr_draft_toggled",
     "pr_replaced",
@@ -56,20 +55,62 @@ class SubmitInvariants:
 class LifecycleScenario:
     name: str
     template: Literal["cleanup_sync", "closed_restart", "direct_merge"]
-    merge_method: Literal["rebase", "squash"] = "squash"
+    stack_size: int
+    merged_prefix: int
+    merge_method: Literal["rebase", "squash"]
 
 
 LIFECYCLE_SCENARIOS = (
-    LifecycleScenario("external-squash-cleanup-sync", "cleanup_sync"),
-    LifecycleScenario("closed-single-cleanup-resubmit", "closed_restart"),
-    LifecycleScenario("direct-rebase-two-of-four", "direct_merge", "rebase"),
-    LifecycleScenario("external-rebase-cleanup-sync", "cleanup_sync", "rebase"),
+    LifecycleScenario("external-squash-cleanup-sync", "cleanup_sync", 1, 1, "squash"),
+    LifecycleScenario("closed-single-cleanup-resubmit", "closed_restart", 1, 1, "squash"),
+    LifecycleScenario("direct-rebase-two-of-four", "direct_merge", 4, 2, "rebase"),
 )
 
 
 def lifecycle_scenarios_from_environment() -> tuple[LifecycleScenario, ...]:
     count = int(os.environ.get("JJ_STACK_SUBMIT_PROPERTY_LIFECYCLE_SCENARIOS", "3"))
-    return LIFECYCLE_SCENARIOS[:count]
+    seed = int(
+        os.environ.get(
+            "JJ_STACK_SUBMIT_PROPERTY_SEED",
+            str(DEFAULT_STACK_EDIT_SCENARIO_SEED),
+        )
+    )
+    return generate_lifecycle_scenarios(count=count, seed=seed)
+
+
+def generate_lifecycle_scenarios(*, count: int, seed: int) -> tuple[LifecycleScenario, ...]:
+    if count < 1:
+        return ()
+    if count <= len(LIFECYCLE_SCENARIOS):
+        return LIFECYCLE_SCENARIOS[:count]
+
+    fixed_direct = LIFECYCLE_SCENARIOS[-1]
+    whole_stack = LifecycleScenario(
+        "direct-squash-four-of-four",
+        "direct_merge",
+        4,
+        4,
+        "squash",
+    )
+    excluded = {
+        (fixed_direct.stack_size, fixed_direct.merged_prefix, fixed_direct.merge_method),
+        (whole_stack.stack_size, whole_stack.merged_prefix, whole_stack.merge_method),
+    }
+    generated = [
+        LifecycleScenario(
+            f"direct-{method}-{prefix}-of-{size}",
+            "direct_merge",
+            size,
+            prefix,
+            method,
+        )
+        for size in range(1, 6)
+        for prefix in range(1, size + 1)
+        for method in ("rebase", "squash")
+        if (size, prefix, method) not in excluded
+    ]
+    random.Random(seed + 6).shuffle(generated)
+    return (*LIFECYCLE_SCENARIOS, whole_stack, *generated)[:count]
 
 
 @dataclass(frozen=True, slots=True)
@@ -157,12 +198,6 @@ DRIFT_KIND_SPECS: dict[DriftKind, DriftKindSpec] = {
         ),
         needs_label=True,
     ),
-    "merged_pr": DriftKindSpec(
-        boundary="github_prs",
-        expected_outcome="fail_closed",
-        failures=((1, "pull_request_not_open"),),
-        needs_label=True,
-    ),
     "pr_base_retargeted": DriftKindSpec(
         boundary="github_prs",
         expected_outcome="success",
@@ -223,9 +258,9 @@ class DriftOperation:
 
 @dataclass(frozen=True, slots=True)
 class ExternalDriftScenario:
-    """A submitted stack, an optional local edit, and one or more boundary drifts.
+    """A submitted stack, an optional local edit, and one boundary drift.
 
-    The scenario model predicts the submit outcome: fail-closed drifts must
+    The scenario model predicts the submit outcome: a fail-closed drift must
     leave every boundary untouched, success drifts must converge on the normal
     post-submit contract. Every scenario also asserts that `view` still
     produces a report for the drifted state instead of crashing.
@@ -235,28 +270,15 @@ class ExternalDriftScenario:
     hazard_class: str
     initial_size: int
     edit_operations: tuple[StackEditOperation, ...]
-    drifts: tuple[DriftOperation, ...]
+    drift: DriftOperation
     final_live_labels: tuple[str, ...]
     orphaned_labels: tuple[str, ...]
     rewritten_initial_labels: tuple[str, ...]
 
     @property
-    def expected_outcome(self) -> DriftOutcome:
-        if any(drift.spec.expected_outcome == "fail_closed" for drift in self.drifts):
-            return "fail_closed"
-        return "success"
-
-    @property
-    def expected_failures(self) -> tuple[tuple[int, str], ...]:
-        failures: set[tuple[int, str]] = set()
-        for drift in self.drifts:
-            failures.update(drift.spec.failures)
-        return tuple(sorted(failures))
-
-    @property
     def trace(self) -> str:
         parts = [operation.trace for operation in self.edit_operations]
-        parts.extend(drift.trace for drift in self.drifts)
+        parts.append(self.drift.trace)
         return ",".join(parts)
 
     @property
@@ -277,12 +299,10 @@ class ExternalDriftScenario:
         tuple[str, ...],
         tuple[str, ...],
         tuple[str, ...],
-        tuple[str, ...],
     ]:
         return (
             self.hazard_class,
-            self.expected_outcome,
-            tuple(sorted(drift.trace for drift in self.drifts)),
+            self.drift.trace,
             self.final_live_labels,
             self.orphaned_labels,
             self.rewritten_initial_labels,
@@ -726,7 +746,7 @@ def generate_external_drift_scenarios(
     count: int,
     seed: int,
 ) -> tuple[ExternalDriftScenario, ...]:
-    """Generate scenarios that perturb one or two boundaries after submit."""
+    """Generate scenarios that perturb one boundary after submit."""
 
     if count < 1:
         return ()
@@ -736,7 +756,6 @@ def generate_external_drift_scenarios(
         tuple[
             str,
             str,
-            tuple[str, ...],
             tuple[str, ...],
             tuple[str, ...],
             tuple[str, ...],
@@ -754,7 +773,7 @@ def generate_external_drift_scenarios(
     while len(scenarios) < count and attempts < max_attempts:
         attempts += 1
         scenario = _random_external_drift_scenario(rng, attempts=attempts)
-        if scenario is None or scenario.canonical_key in seen:
+        if scenario.canonical_key in seen:
             continue
         seen.add(scenario.canonical_key)
         scenarios.append(scenario)
@@ -771,7 +790,7 @@ def _fixed_external_drift_scenarios() -> tuple[ExternalDriftScenario, ...]:
 
 def _closed_pr_after_insert_scenario() -> ExternalDriftScenario:
     return _drift_scenario(
-        drifts=(DriftOperation(kind="closed_pr", label="c2"),),
+        drift=DriftOperation(kind="closed_pr", label="c2"),
         edit_operations=(StackEditOperation(kind="insert_after", label="c1", new_label="i1"),),
         hazard_class="github-external-close-with-unsubmitted-change",
         name="closed-pr-after-insert",
@@ -780,7 +799,7 @@ def _closed_pr_after_insert_scenario() -> ExternalDriftScenario:
 
 def _drift_scenario(
     *,
-    drifts: tuple[DriftOperation, ...],
+    drift: DriftOperation,
     hazard_class: str,
     name: str,
     edit_operations: tuple[StackEditOperation, ...] = (),
@@ -790,7 +809,7 @@ def _drift_scenario(
     for operation in edit_operations:
         model = model.append(operation)
     return ExternalDriftScenario(
-        drifts=drifts,
+        drift=drift,
         edit_operations=edit_operations,
         final_live_labels=model.live_labels,
         hazard_class=hazard_class,
@@ -805,7 +824,7 @@ def _random_external_drift_scenario(
     rng: random.Random,
     *,
     attempts: int,
-) -> ExternalDriftScenario | None:
+) -> ExternalDriftScenario:
     initial_size = rng.randint(2, 5)
     model = _model(initial_size)
     edit_operations: tuple[StackEditOperation, ...] = ()
@@ -816,11 +835,8 @@ def _random_external_drift_scenario(
             model = model.append(operation)
             edit_operations = (operation,)
 
-    drifts = _random_drift_operations(rng, model=model)
-    if not drifts:
-        return None
     return ExternalDriftScenario(
-        drifts=drifts,
+        drift=_random_drift_operation(rng, model=model),
         edit_operations=edit_operations,
         final_live_labels=model.live_labels,
         hazard_class="random",
@@ -831,34 +847,25 @@ def _random_external_drift_scenario(
     )
 
 
-def _random_drift_operations(
+def _random_drift_operation(
     rng: random.Random,
     *,
     model: _ScenarioModel,
-) -> tuple[DriftOperation, ...]:
+) -> DriftOperation:
     live_initial_labels = [label for label in model.live_labels if label.startswith("c")]
-    drift_count = rng.choice((1, 1, 2))
-    kinds = rng.sample(
-        _GENERATED_DRIFT_KINDS,
-        k=min(drift_count, len(_GENERATED_DRIFT_KINDS)),
+    candidates = [
+        DriftOperation(kind=kind, label=label)
+        for kind in _GENERATED_DRIFT_KINDS
+        if DRIFT_KIND_SPECS[kind].needs_label
+        for label in live_initial_labels
+        if _drift_label_is_valid(kind, label=label, model=model)
+    ]
+    candidates.extend(
+        DriftOperation(kind=kind)
+        for kind in _GENERATED_DRIFT_KINDS
+        if not DRIFT_KIND_SPECS[kind].needs_label
     )
-    drifts: list[DriftOperation] = []
-    available_labels = list(live_initial_labels)
-    for kind in kinds:
-        if not DRIFT_KIND_SPECS[kind].needs_label:
-            drifts.append(DriftOperation(kind=kind))
-            continue
-        candidates = [
-            label
-            for label in available_labels
-            if _drift_label_is_valid(kind, label=label, model=model)
-        ]
-        if not candidates:
-            continue
-        label = rng.choice(candidates)
-        available_labels.remove(label)
-        drifts.append(DriftOperation(kind=kind, label=label))
-    return tuple(drifts)
+    return rng.choice(candidates)
 
 
 def _drift_label_is_valid(kind: DriftKind, *, label: str, model: _ScenarioModel) -> bool:

--- a/tests/unit/test_property_runner.py
+++ b/tests/unit/test_property_runner.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests import run_submit_property_scenarios as property_runner
 
 
@@ -31,3 +33,18 @@ def test_reproduction_command_preserves_scenario_budgets_and_pytest_filter() -> 
         option_index = command.index(option)
         assert command[option_index + 1] == env[environment_name]
     assert command[-4:] == ("--no-sync", "--", "-k", "external_drift")
+
+
+def test_runner_requires_separator_before_pytest_arguments(monkeypatch) -> None:
+    commands: list[tuple[str, ...]] = []
+
+    def run(command, **_kwargs):
+        commands.append(tuple(command))
+        return property_runner.subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(property_runner.subprocess, "run", run)
+
+    assert property_runner.main(("1", "--no-sync", "--", "-k", "external_drift")) == 0
+    assert commands[0][-2:] == ("-k", "external_drift")
+    with pytest.raises(SystemExit):
+        property_runner.main(("1", "--no-sync", "-k", "external_drift"))

--- a/tests/unit/test_property_scenarios.py
+++ b/tests/unit/test_property_scenarios.py
@@ -6,7 +6,6 @@ from tests.support.stack_edit_scenarios import (
     move_after_candidates,
     move_before_candidates,
 )
-from tests.support.submit_property_scenarios import DriftOperation, ExternalDriftScenario
 
 
 @pytest.mark.parametrize(
@@ -53,25 +52,3 @@ def test_shared_move_candidates_exclude_adjacent_no_ops() -> None:
     assert ("c1", "c2") not in move_before_candidates(labels)
     assert ("c1", "c2") in move_after_candidates(labels)
     assert ("c3", "c2") in move_before_candidates(labels)
-
-
-def test_composed_drift_keeps_exit_codes_paired_with_their_diagnoses() -> None:
-    scenario = ExternalDriftScenario(
-        name="mixed-failures",
-        hazard_class="unit",
-        initial_size=2,
-        edit_operations=(),
-        drifts=(
-            DriftOperation(kind="closed_pr", label="c1"),
-            DriftOperation(kind="foreign_branch_fetched", label="c2"),
-        ),
-        final_live_labels=("c1", "c2"),
-        orphaned_labels=(),
-        rewritten_initial_labels=(),
-    )
-
-    assert scenario.expected_failures == (
-        (1, "pull_request_not_open"),
-        (2, "unsupported_stack:divergent_change"),
-        (2, "unsupported_stack:immutable_commit"),
-    )


### PR DESCRIPTION
CI passed an unknown runner option and collected no property scenarios. Make
runner options strict, remove impossible compound drift modeling, and
explore the finite direct merge and automatic-sync parameter space.